### PR TITLE
feat: use structured --format json for read commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2026-05-22
+
+Use Pebble's structured `--format json` output for read commands
+(`get_services`, `get_checks`, `list_files`, `get_changes`, `get_change`,
+`get_identities`). This is more robust than scraping human-readable tables and
+restores information the text parser had to drop or guess: change `kind`,
+`tasks` and `err`; check `successes`/`failures`/`threshold`/`change_id`; real
+file `user_id`/`group_id`/`size`/`type`; and identity local `user_id`.
+
+Requires a Pebble build that supports `--format` on read commands.
+
 # 2025-07-25
 
 Add missing overloads on pull() and exec().

--- a/README.md
+++ b/README.md
@@ -136,13 +136,17 @@ Other minor limitations:
 - `replan_services()`, `start_services()`, `stop_services()`, and `restart_services()` are only able to return the change ID if no timeout is set.
 - `notify()` only supports custom notices.
 - `get_notices()` cannot include the `last_occurred`, `last_data`, `repeat_after`, or `expire_after` fields
-- `get_changes()` cannot include the `kind`, `tasks`, `err`, `ready_time`, or `data` fields, and guesses at the `ready` field
 - `autostart_services()` is an alias for `replan()` (possibly we could fix this by getting the current state?)
 - `wait_change()` is yet to be implemented
 - `ack_warnings()` is yet to be implemented
 - `get_warnings()` is only implemented for the 'no warnings' case
-- `list_file()` looks up the user and group IDs locally, which is very likely to be wrong
-- `get_identities()` is unable to get the user ID for local identities
+
+`get_services()`, `get_checks()`, `list_files()`, `get_changes()`,
+`get_change()`, and `get_identities()` use Pebble's structured `--format json`
+output, so they return the same rich data as `ops.pebble.Client` (including
+change `kind`/`tasks`/`err`, check thresholds, real file ownership, and local
+identity user IDs). This requires a Pebble build that supports `--format` on
+read commands.
 
 ## Comparison with ops.pebble.Client
 

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import datetime
 import fnmatch
 import io
+import json
 import os
 import pathlib
 import signal
@@ -24,7 +25,6 @@ import yaml
 # Import all the types and exceptions from ops.pebble for compatibility
 from ops.pebble import (
     APIError,
-    BasicIdentity,
     Change,
     ChangeID,
     ChangeState,
@@ -32,11 +32,9 @@ from ops.pebble import (
     CheckLevel,
     ConnectionError,
     FileInfo,
-    FileType,
     Identity,
     IdentityDict,
     Layer,
-    LocalIdentity,
     Notice,
     NoticesUsers,
     NoticeType,
@@ -107,6 +105,25 @@ class PebbleCliClient:
                 f"Pebble binary not found: {self.pebble_binary}"
             ) from e
 
+    def _run_json(
+        self,
+        cmd: list[str],
+        timeout: float | None = None,
+    ) -> Any:
+        """Run a read command with ``--format json`` and return parsed JSON.
+
+        The structured output emitted by Pebble's read commands matches the
+        wire format produced by the Pebble API, so the result can be passed
+        straight to the matching ``ops.pebble`` ``from_dict`` constructor. This
+        is both more robust and richer than scraping the human-readable tables
+        (which drop fields such as a change's kind, tasks, and error).
+        """
+        result = self._run_command([*cmd, "--format", "json"], timeout=timeout)
+        output = result.stdout.strip()
+        if not output:
+            return None
+        return json.loads(output)
+
     def get_system_info(self) -> SystemInfo:
         """Get system information."""
         result = self._run_command(["version", "--client"])
@@ -164,27 +181,13 @@ class PebbleCliClient:
 
     def get_services(self, names: Iterable[str] | None = None) -> list[ServiceInfo]:
         """Get service status information."""
-        filtered_names = set(names) if names else None
-        cmd = ["services", "--abs-time"]
-        result = self._run_command(cmd)
-        if result.stdout.strip() == "Plan has no services.":
+        cmd = ["services"]
+        if names:
+            cmd.extend(names)
+        data = self._run_json(cmd)
+        if not data:
             return []
-        # Output looks like:
-        # Service      Startup  Current  Since
-        # demo-server  enabled  active   2025-07-12T06:55:57Z
-        lines = result.stdout.strip().splitlines()[1:]
-        services: list[ServiceInfo] = []
-        for line in lines:
-            if not line.strip():
-                continue
-            parts = line.split()
-            if len(parts) < 4:
-                continue
-            service, startup, current, _ = parts
-            if filtered_names is not None and service not in filtered_names:
-                continue
-            services.append(ServiceInfo(name=service, startup=startup, current=current))
-        return services
+        return [ServiceInfo.from_dict(svc) for svc in data["services"].values()]
 
     def start_services(
         self,
@@ -299,21 +302,13 @@ class PebbleCliClient:
         cmd = ["checks"]
         if level:
             cmd.extend(["--level", level.value])
+        if names:
+            cmd.extend(names)
 
-        result = self._run_command(cmd)
-
-        checks = []
-        lines = result.stdout.strip().split("\n")
-        for line in lines[1:]:
-            if not line.strip():
-                continue
-            parts = line.split()
-            if len(parts) >= 3:
-                check_name = parts[0]
-                if names and check_name not in names:
-                    continue
-                checks.append(CheckInfo(check_name, parts[1], parts[2]))
-        return checks
+        data = self._run_json(cmd)
+        if not data:
+            return []
+        return [CheckInfo.from_dict(check) for check in data["checks"].values()]
 
     def start_checks(self, checks: Iterable[str]) -> list[str]:
         """Start checks."""
@@ -348,79 +343,18 @@ class PebbleCliClient:
         itself: bool = False,
     ) -> list[FileInfo]:
         """List files in a directory."""
-        cmd = ["ls", "--abs-time", "-l", path]
+        cmd = ["ls", path]
         if itself:
             cmd.append("-d")
 
-        result = self._run_command(cmd)
-        # Output looks like:
-        # drwxr-xr-x  root  root       -  2025-07-12T06:43:11Z  dev
-
-        files = []
-        lines = result.stdout.strip().split("\n")
-        for line in lines:
-            if not line.strip():
-                continue
-            parts = line.split(None, 6)
-            if len(parts) < 6:
-                continue
-            name = parts[-1]
-            if pattern and not fnmatch.fnmatch(name, pattern):
-                continue
-            permissions = self._permissions_to_int(parts[0][1:])
-            user = parts[1]
-            user_id = 0 if user == "root" else os.getuid()
-            group = parts[2]
-            group_id = 0 if group == "root" else os.getgid()
-            file_info = FileInfo(
-                path=path,
-                name=name,
-                type=FileType.DIRECTORY if parts[0].startswith("d") else FileType.FILE,
-                permissions=permissions,
-                user=user,
-                user_id=user_id,
-                group=group,
-                group_id=group_id,
-                size=self._human_size_to_int(parts[3]),
-                last_modified=datetime.datetime.fromisoformat(parts[4]),
-            )
-            files.append(file_info)
+        data = self._run_json(cmd)
+        files = [FileInfo.from_dict(entry) for entry in (data or {}).get("files", [])]
+        # ``pattern`` matches against entry names; Pebble's ls glob support only
+        # applies to the final path element, so filter here to match the
+        # ops.pebble.Client semantics exactly.
+        if pattern:
+            files = [f for f in files if fnmatch.fnmatch(f.name, pattern)]
         return files
-
-    @staticmethod
-    def _human_size_to_int(size: str) -> int | None:
-        """Convert human-readable size (e.g., '1K', '2M') to bytes."""
-        if size == "-":
-            return None
-        size = size.strip().upper()
-        if size.endswith("KB"):
-            return int(size[:-2]) * 1024
-        elif size.endswith("MB"):
-            return int(size[:-2]) * 1024 * 1024
-        elif size.endswith("GB"):
-            return int(size[:-2]) * 1024 * 1024 * 1024
-        elif size.endswith("B"):
-            return int(size[:-1])
-        else:
-            raise ValueError(f"Invalid size format: {size}")
-
-    @staticmethod
-    def _permissions_to_int(perm_string: str, /):
-        """Convert a permission string like 'rw-rw-r--' to an integer."""
-        if len(perm_string) != 9:
-            raise ValueError("Permission string must be exactly 9 characters")
-
-        result = 0
-        for i in range(0, 9, 3):
-            group_value = 0
-            if perm_string[i] == "r":
-                group_value += 4
-            if perm_string[i + 1] == "w":
-                group_value += 2
-            if perm_string[i + 2] == "x":
-                group_value += 1
-            result = (result << 3) | group_value
-        return result
 
     def make_dir(
         self,
@@ -665,17 +599,20 @@ class PebbleCliClient:
 
     # Change management
     def get_change(self, change_id: ChangeID) -> Change:
-        changes = self.get_changes()
-        for change in changes:
-            if change.id == change_id:
-                return change
-        message = f"Could not find change {change_id}"
-        raise APIError(
-            body={"message": message},
-            code=404,
-            status="Command Failed",
-            message=message,
-        )
+        # ``pebble tasks <id>`` returns the full change object (kind, tasks,
+        # error and timing included), so we get the complete change directly
+        # rather than scanning the whole list.
+        try:
+            data = self._run_json(["tasks", str(change_id)])
+        except APIError as e:
+            message = f"Could not find change {change_id}"
+            raise APIError(
+                body={"message": message},
+                code=404,
+                status="Command Failed",
+                message=message,
+            ) from e
+        return Change.from_dict(data)
 
     def get_changes(
         self,
@@ -683,57 +620,20 @@ class PebbleCliClient:
         service: str | None = None,
     ) -> list[Change]:
         """Get list of changes."""
-        cmd = ["changes", "--abs-time"]
-        if select:
-            cmd.extend(["--select", str(select)])
+        cmd = ["changes"]
+        if service:
+            cmd.append(service)
 
-        result = self._run_command(cmd)
-
-        # Parse changes output.
-        # Output looks like:
-        # ID   Status  Spawn                 Ready                 Summary
-        # 1    Error   2025-07-12T06:49:22Z  2025-07-12T06:50:52Z  Perform HTTP check "demo-health"
-        changes: list[Change] = []
-        lines = result.stdout.strip().splitlines()
-        if not lines or len(lines) < 2 or lines[0].strip() == "No changes.":
-            return changes
-
-        header = lines[0]
-        # Find column start indices by header.
-        columns = ["ID", "Status", "Spawn", "Ready", "Summary"]
-        col_starts: list[int | None] = []
-        for col in columns:
-            idx = header.find(col)
-            if idx == -1:
-                raise ValueError(f"Column '{col}' not found in header: {header}")
-            col_starts.append(idx)
-        # Add end index for easier slicing.
-        col_starts.append(None)
-
-        for line in lines[1:]:
-            if not line.strip():
-                continue
-            fields: list[str] = []
-            for i in range(len(columns)):
-                start = col_starts[i]
-                end = col_starts[i + 1]
-                value = (
-                    line[start:end].strip() if end is not None else line[start:].strip()
-                )
-                fields.append(value)
-            if len(fields) == 5:
-                change = Change(
-                    id=fields[0],
-                    kind="unknown",  # Kind is not available in CLI output
-                    tasks=[],  # Tasks are not available in CLI output
-                    ready=fields[0] in ("Done", "Error"),
-                    err=None,  # Error is not available in CLI output
-                    status=fields[1],
-                    spawn_time=datetime.datetime.fromisoformat(fields[2]),
-                    ready_time=None,
-                    summary=fields[4],
-                )
-            changes.append(change)
+        data = self._run_json(cmd)
+        if not data:
+            return []
+        changes = [Change.from_dict(change) for change in data["changes"]]
+        # The CLI always returns every change; apply the ``select`` filter here
+        # to match ops.pebble.Client semantics.
+        if select == ChangeState.READY:
+            changes = [c for c in changes if c.ready]
+        elif select == ChangeState.IN_PROGRESS:
+            changes = [c for c in changes if not c.ready]
         return changes
 
     def wait_change(
@@ -865,28 +765,13 @@ class PebbleCliClient:
 
     def get_identities(self) -> dict[str, Identity]:
         """Get all identities."""
-        cmd = ["identities"]
-        result = self._run_command(cmd)
-
-        identities = {}
-        lines = result.stdout.strip().split("\n")
-        if lines == ["No identities."]:
-            return identities
-
-        for line in lines[1:]:  # Skip header
-            if not line.strip():
-                continue
-
-            parts = line.split()
-            if len(parts) >= 2:
-                name = parts[0]
-                access = parts[1]
-                types = parts[2].split(",")
-                basic = BasicIdentity("*****") if "basic" in types else None
-                local = LocalIdentity(user_id=-1) if "local" in types else None
-                identities[name] = Identity(access, basic=basic, local=local)
-
-        return identities
+        data = self._run_json(["identities"])
+        if not data:
+            return {}
+        return {
+            name: Identity.from_dict(identity)
+            for name, identity in data["identities"].items()
+        }
 
     def replace_identities(
         self,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -184,34 +184,66 @@ class TestPebbleCliClient:
 
     def test_get_services(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting services."""
-        text_output = """Service  Startup   Current  Since
-service1 enabled  active  2025-07-12T06:55:57Z
-service2 disabled inactive  2025-07-12T06:55:57Z"""
-        mock_subprocess.run.return_value.stdout = text_output
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "services": {
+                    "service1": {
+                        "name": "service1",
+                        "startup": "enabled",
+                        "current": "active",
+                        "current-since": "2025-07-12T06:55:57Z",
+                    },
+                    "service2": {
+                        "name": "service2",
+                        "startup": "disabled",
+                        "current": "inactive",
+                    },
+                }
+            }
+        )
 
         services = client.get_services()
 
         assert len(services) == 2
-        assert services[0].name == "service1"
-        assert services[0].startup == "enabled"
-        assert services[0].current == "active"
-        assert services[1].name == "service2"
-        assert services[1].startup == "disabled"
-        assert services[1].current == "inactive"
+        by_name = {svc.name: svc for svc in services}
+        assert by_name["service1"].startup == ops.pebble.ServiceStartup.ENABLED
+        assert by_name["service1"].current == ops.pebble.ServiceStatus.ACTIVE
+        assert by_name["service2"].startup == ops.pebble.ServiceStartup.DISABLED
+        assert by_name["service2"].current == ops.pebble.ServiceStatus.INACTIVE
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "services", "--format", "json"]
 
     def test_get_services_filtered(
         self, mock_subprocess: Mock, client: PebbleCliClient
     ):
         """Test getting specific services by name."""
-        text_output = """Service  Startup   Current  Since
-service1 enabled  active  2025-07-12T06:55:57Z
-service2 disabled inactive  2025-07-12T06:55:57Z"""
-        mock_subprocess.run.return_value.stdout = text_output
+        # Pebble does the name filtering itself, so it only returns the match.
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "services": {
+                    "service1": {
+                        "name": "service1",
+                        "startup": "enabled",
+                        "current": "active",
+                    },
+                }
+            }
+        )
 
         services = client.get_services(names=["service1"])
 
         assert len(services) == 1
         assert services[0].name == "service1"
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == [
+            "mock-pebble",
+            "services",
+            "service1",
+            "--format",
+            "json",
+        ]
 
     def test_start_services(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test starting services."""
@@ -266,29 +298,55 @@ service2 disabled inactive  2025-07-12T06:55:57Z"""
 
     def test_get_checks(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting check status."""
-        text_output = """Check     Level  Status
-check1    alive  up
-check2    ready  down"""
-        mock_subprocess.run.return_value.stdout = text_output
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "checks": {
+                    "check1": {
+                        "name": "check1",
+                        "level": "alive",
+                        "status": "up",
+                        "successes": 5,
+                        "failures": 0,
+                        "threshold": 3,
+                        "change-id": "1",
+                    },
+                    "check2": {
+                        "name": "check2",
+                        "level": "ready",
+                        "status": "down",
+                        "successes": 0,
+                        "failures": 3,
+                        "threshold": 3,
+                        "change-id": "2",
+                    },
+                }
+            }
+        )
 
         checks = client.get_checks()
 
         assert len(checks) == 2
-        assert checks[0].name == "check1"
-        assert checks[0].level == "alive"
-        assert checks[0].status == "up"
+        by_name = {check.name: check for check in checks}
+        assert by_name["check1"].level == ops.pebble.CheckLevel.ALIVE
+        assert by_name["check1"].status == ops.pebble.CheckStatus.UP
+        # The JSON format exposes the richer detail that text parsing dropped.
+        assert by_name["check1"].successes == 5
+        assert by_name["check1"].threshold == 3
+        assert by_name["check2"].failures == 3
+        assert by_name["check2"].status == ops.pebble.CheckStatus.DOWN
 
     def test_get_checks_with_level(
         self, mock_subprocess: Mock, client: PebbleCliClient
     ):
         """Test getting checks filtered by level."""
-        mock_subprocess.run.return_value.stdout = "Check Level Status\n"
+        mock_subprocess.run.return_value.stdout = json.dumps({"checks": {}})
 
         client.get_checks(level=ops.pebble.CheckLevel.ALIVE)
 
         call_args = mock_subprocess.run.call_args[0][0]
         assert "--level" in call_args
         assert "alive" in call_args
+        assert call_args[-2:] == ["--format", "json"]
 
     def test_start_checks(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test starting checks."""
@@ -308,36 +366,85 @@ check2    ready  down"""
 
     def test_list_files(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test listing files."""
-        text_output = """
-drwxr-xr-x  root  root       -  2024-02-26T12:58:31Z  bin
--rw-------  ubuntu  ubuntu   811kB  2025-07-12T09:15:20Z  .pebble.state
-""".strip()
-        mock_subprocess.run.return_value.stdout = text_output
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "/path/bin",
+                        "name": "bin",
+                        "type": "directory",
+                        "permissions": "755",
+                        "last-modified": "2024-02-26T12:58:31Z",
+                        "user-id": 0,
+                        "user": "root",
+                        "group-id": 0,
+                        "group": "root",
+                    },
+                    {
+                        "path": "/path/.pebble.state",
+                        "name": ".pebble.state",
+                        "type": "file",
+                        "size": 830464,
+                        "permissions": "600",
+                        "last-modified": "2025-07-12T09:15:20Z",
+                        "user-id": 1000,
+                        "user": "ubuntu",
+                        "group-id": 1000,
+                        "group": "ubuntu",
+                    },
+                ]
+            }
+        )
 
         files = client.list_files("/path")
 
         assert len(files) == 2
         assert files[0].name == "bin"
+        assert files[0].type == ops.pebble.FileType.DIRECTORY
         assert files[0].permissions == 0o755
         assert files[0].user == "root"
         assert files[0].group == "root"
         assert files[1].name == ".pebble.state"
         assert files[1].permissions == 0o0600
+        assert files[1].size == 830464
         assert files[1].user == "ubuntu"
         assert files[1].group == "ubuntu"
+        # The JSON format provides real numeric IDs (text output had none).
+        assert files[1].user_id == 1000
+        assert files[1].group_id == 1000
 
         call_args = mock_subprocess.run.call_args[0][0]
-        assert call_args == ["mock-pebble", "ls", "--abs-time", "-l", "/path"]
+        assert call_args == ["mock-pebble", "ls", "/path", "--format", "json"]
 
     def test_list_files_with_pattern(
         self, mock_subprocess: Mock, client: PebbleCliClient
     ):
         """Test listing files with pattern."""
-        text_output = """
-drwxr-xr-x  root  root       -  2024-02-26T12:58:31Z  bin
--rw-------  ubuntu  ubuntu   811kB  2025-07-12T09:15:20Z  .pebble.txt
-""".strip()
-        mock_subprocess.run.return_value.stdout = text_output
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "/path/bin",
+                        "name": "bin",
+                        "type": "directory",
+                        "permissions": "755",
+                        "last-modified": "2024-02-26T12:58:31Z",
+                        "user": "root",
+                        "group": "root",
+                    },
+                    {
+                        "path": "/path/.pebble.txt",
+                        "name": ".pebble.txt",
+                        "type": "file",
+                        "size": 12,
+                        "permissions": "600",
+                        "last-modified": "2025-07-12T09:15:20Z",
+                        "user": "ubuntu",
+                        "group": "ubuntu",
+                    },
+                ]
+            }
+        )
 
         files = client.list_files("/path", pattern="*.txt")
 
@@ -445,14 +552,48 @@ drwxr-xr-x  root  root       -  2024-02-26T12:58:31Z  bin
         assert "--user" in call_args
         assert "testuser" in call_args
 
+    @staticmethod
+    def _changes_json() -> str:
+        return json.dumps(
+            {
+                "changes": [
+                    {
+                        "id": "1",
+                        "kind": "perform-check",
+                        "summary": 'Perform HTTP check "demo-health"',
+                        "status": "Error",
+                        "tasks": [
+                            {
+                                "id": "1",
+                                "kind": "perform-check",
+                                "summary": 'Perform HTTP check "demo-health"',
+                                "status": "Error",
+                                "progress": {"label": "", "done": 1, "total": 1},
+                                "spawn-time": "2025-07-12T06:49:22Z",
+                                "ready-time": "2025-07-12T06:50:52Z",
+                            }
+                        ],
+                        "ready": True,
+                        "err": 'check "demo-health" failed',
+                        "spawn-time": "2025-07-12T06:49:22Z",
+                        "ready-time": "2025-07-12T06:50:52Z",
+                    },
+                    {
+                        "id": "2",
+                        "kind": "exec",
+                        "summary": 'Execute command "echo"',
+                        "status": "Doing",
+                        "tasks": [],
+                        "ready": False,
+                        "spawn-time": "2025-07-12T06:49:22Z",
+                    },
+                ]
+            }
+        )
+
     def test_get_changes(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting changes."""
-        text_output = """
-ID   Status  Spawn                 Ready                 Summary
-1    Error   2025-07-12T06:49:22Z  2025-07-12T06:50:52Z  Perform HTTP check "demo-health"
-2    Done    2025-07-12T06:49:22Z  2025-07-12T06:49:22Z  Execute command "echo"
-""".strip()
-        mock_subprocess.run.return_value.stdout = text_output
+        mock_subprocess.run.return_value.stdout = self._changes_json()
 
         changes = client.get_changes()
 
@@ -460,9 +601,77 @@ ID   Status  Spawn                 Ready                 Summary
         assert changes[0].id == "1"
         assert changes[0].status == "Error"
         assert changes[0].summary == 'Perform HTTP check "demo-health"'
+        # The JSON format restores fields the text parser had to fake.
+        assert changes[0].kind == "perform-check"
+        assert changes[0].err == 'check "demo-health" failed'
+        assert len(changes[0].tasks) == 1
+        assert changes[0].tasks[0].kind == "perform-check"
+        assert changes[0].ready_time is not None
         assert changes[1].id == "2"
-        assert changes[1].status == "Done"
+        assert changes[1].kind == "exec"
+        assert changes[1].status == "Doing"
         assert changes[1].summary == 'Execute command "echo"'
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "changes", "--format", "json"]
+
+    def test_get_changes_select(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """Test that the select filter is applied client-side."""
+        mock_subprocess.run.return_value.stdout = self._changes_json()
+        ready = client.get_changes(select=ops.pebble.ChangeState.READY)
+        assert [c.id for c in ready] == ["1"]
+
+        mock_subprocess.run.return_value.stdout = self._changes_json()
+        in_progress = client.get_changes(select=ops.pebble.ChangeState.IN_PROGRESS)
+        assert [c.id for c in in_progress] == ["2"]
+
+    def test_get_changes_for_service(
+        self, mock_subprocess: Mock, client: PebbleCliClient
+    ):
+        """Test that a service filter is passed through as a positional arg."""
+        mock_subprocess.run.return_value.stdout = json.dumps({"changes": []})
+        client.get_changes(service="demo-server")
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == [
+            "mock-pebble",
+            "changes",
+            "demo-server",
+            "--format",
+            "json",
+        ]
+
+    def test_get_change(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """Test getting a single change by ID via the tasks command."""
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "id": "2",
+                "kind": "exec",
+                "summary": 'Execute command "echo"',
+                "status": "Done",
+                "tasks": [
+                    {
+                        "id": "2",
+                        "kind": "exec",
+                        "summary": 'Execute command "echo"',
+                        "status": "Done",
+                        "progress": {"label": "", "done": 1, "total": 1},
+                        "spawn-time": "2025-07-12T06:49:22Z",
+                        "ready-time": "2025-07-12T06:49:23Z",
+                    }
+                ],
+                "ready": True,
+                "spawn-time": "2025-07-12T06:49:22Z",
+                "ready-time": "2025-07-12T06:49:23Z",
+            }
+        )
+
+        change = client.get_change(ops.pebble.ChangeID("2"))
+
+        assert change.id == "2"
+        assert change.kind == "exec"
+        assert len(change.tasks) == 1
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "tasks", "2", "--format", "json"]
 
     def test_get_notices(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting notices."""
@@ -501,12 +710,19 @@ ID   User    Type           Key                    First                 Repeate
 
     def test_get_identities(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting identities."""
-        text_output = """
-Name     Access   Types
-alice    admin    basic
-bob      metrics  local
-charlie  read     basic,local""".strip()
-        mock_subprocess.run.return_value.stdout = text_output
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "identities": {
+                    "alice": {"access": "admin", "basic": {"password": "*****"}},
+                    "bob": {"access": "metrics", "local": {"user-id": 1000}},
+                    "charlie": {
+                        "access": "read",
+                        "basic": {"password": "*****"},
+                        "local": {"user-id": 1001},
+                    },
+                }
+            }
+        )
 
         identities = client.get_identities()
 
@@ -519,10 +735,13 @@ charlie  read     basic,local""".strip()
         assert identities["bob"].access == "metrics"
         assert identities["bob"].basic is None
         assert identities["bob"].local is not None
+        # The JSON format carries the real local user-id (text output faked it).
+        assert identities["bob"].local.user_id == 1000
         assert identities["charlie"].access == "read"
         assert identities["charlie"].basic is not None
         assert identities["charlie"].basic.password == "*****"
         assert identities["charlie"].local is not None
+        assert identities["charlie"].local.user_id == 1001
 
 
 class TestCompatibilityWithOpsPebble:


### PR DESCRIPTION
Pebble's new --format json output (services, checks, ls, changes, tasks, identities) returns the same wire format the Pebble API produces, so it can be passed straight to the ops.pebble from_dict constructors. This is more robust than scraping human-readable tables and restores information the text parser had to drop or guess:

- changes: real kind, tasks, err, ready_time (were hardcoded)
- checks: successes/failures/threshold/change_id/startup
- files: real user_id/group_id/size/type (were guessed)
- identities: real local user_id (was faked as -1)

get_change() now fetches a single change directly via `tasks <id>` rather than scanning the full list. Name/level filtering is delegated to Pebble; the changes `select` filter is applied client-side as the CLI has no --select flag.

Requires a Pebble build that supports --format on read commands.