### PR TITLE
fix: correctness bugs, py.typed, and CI integration gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Pebble (for integration tests)
-      if: matrix.test-type == 'integration'
       run: |
         sudo snap install pebble
         echo "/snap/bin" >> $GITHUB_PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2026-05-22
+
+Bug fixes and packaging:
+
+- `get_warnings()` now correctly returns an empty list when there are no
+  warnings (it previously always raised `NotImplementedError`).
+- `notify()` raises `ValueError` (instead of `assert`-ing) for non-custom
+  notice types, and renders `repeat_after` as a valid Pebble duration string.
+- `socket_path` now also sets the `PEBBLE_SOCKET` environment variable, as
+  documented.
+- Ship a `py.typed` marker so downstream type checkers use Shimmer's types.
+- `__version__` is derived from the installed package metadata.
+
 # 2025-07-25
 
 Add missing overloads on pull() and exec().

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Shimmer provides `PebbleCliClient`, a class that implements the same interface a
 ### Install from PyPI
 
 ```bash
-uv pip install shimmer
+uv pip install pebble-shimmer
 ```
 
 ### Install development version

--- a/src/shimmer/__init__.py
+++ b/src/shimmer/__init__.py
@@ -1,8 +1,14 @@
 """Shimmer - A drop-in replacement for ops.pebble.Client."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from ._client import PebbleCliClient
 from ._process import ExecProcess
 from ._protocol import PebbleClientProtocol
 
 __all__ = ["PebbleCliClient", "ExecProcess", "PebbleClientProtocol"]
-__version__ = "1.0.0a1"
+
+try:
+    __version__ = version("pebble-shimmer")
+except PackageNotFoundError:  # pragma: no cover - running from an uninstalled tree
+    __version__ = "0.0.0+unknown"

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -837,7 +837,7 @@ class PebbleCliClient:
         if type.value != "custom":
             raise ValueError("Only custom notices are supported")
         cmd = ["notify"]
-        if repeat_after:
+        if repeat_after is not None:
             # Pebble expects a Go duration string (e.g. "1800s"), not bare seconds.
             cmd.extend(["--repeat-after", f"{repeat_after.total_seconds()}s"])
         cmd.append(key)

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -70,7 +70,10 @@ class PebbleCliClient:
         self.pebble_binary = pebble_binary
         self._env = os.environ.copy()
         if socket_path:
+            # Mirror the two environment variables the Pebble CLI honours: PEBBLE
+            # is the daemon directory and PEBBLE_SOCKET overrides the socket path.
             self._env["PEBBLE"] = str(pathlib.Path(socket_path).parent)
+            self._env["PEBBLE_SOCKET"] = socket_path
 
     def _run_command(
         self,
@@ -831,10 +834,12 @@ class PebbleCliClient:
         repeat_after: datetime.timedelta | None = None,
     ) -> str:
         """Record a notice."""
-        assert type.value == "custom", "Only custom notices are supported"
+        if type.value != "custom":
+            raise ValueError("Only custom notices are supported")
         cmd = ["notify"]
         if repeat_after:
-            cmd.extend(["--repeat-after", str(repeat_after.total_seconds())])
+            # Pebble expects a Go duration string (e.g. "1800s"), not bare seconds.
+            cmd.extend(["--repeat-after", f"{repeat_after.total_seconds()}s"])
         cmd.append(key)
         for name, value in (data or {}).items():
             cmd.extend([f"{name}={value}"])
@@ -853,11 +858,13 @@ class PebbleCliClient:
             cmd.extend(["--select", str(select)])
 
         result = self._run_command(cmd)
-        warnings: list[Warning] = []
-        if result == "No warnings.":
-            return warnings
+        output = result.stdout.strip()
+        if not output or output == "No warnings.":
+            return []
 
-        raise NotImplementedError
+        raise NotImplementedError(
+            "Parsing of non-empty warnings output is not yet implemented"
+        )
 
     def ack_warnings(self, timestamp: datetime.datetime) -> int:
         """Acknowledge warnings up to timestamp."""

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,6 +2,7 @@
 
 """Unit tests for Shimmer - Pebble CLI Client."""
 
+import datetime
 import inspect
 import io
 import json
@@ -502,8 +503,6 @@ ID   User    Type           Key                    First                 Repeate
 
     def test_notify_repeat_after(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test that repeat_after is rendered as a Pebble duration string."""
-        import datetime
-
         mock_subprocess.run.return_value.stdout = "Recorded notice 91"
 
         client.notify(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -48,6 +48,7 @@ class TestPebbleCliClient:
 
         expected_pebble_dir = "/tmp/test"
         assert client._env["PEBBLE"] == expected_pebble_dir  # type: ignore
+        assert client._env["PEBBLE_SOCKET"] == socket_path  # type: ignore
 
     def test_run_command_success(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test successful command execution."""
@@ -498,6 +499,36 @@ ID   User    Type           Key                    First                 Repeate
         assert notice_id == "90"
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "notify", "test.example/key", "msg=test"]
+
+    def test_notify_repeat_after(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """Test that repeat_after is rendered as a Pebble duration string."""
+        import datetime
+
+        mock_subprocess.run.return_value.stdout = "Recorded notice 91"
+
+        client.notify(
+            ops.pebble.NoticeType.CUSTOM,
+            "test.example/key",
+            repeat_after=datetime.timedelta(minutes=30),
+        )
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert "--repeat-after" in call_args
+        # 30 minutes -> "1800.0s", a valid Go duration (not a bare "1800.0").
+        assert call_args[call_args.index("--repeat-after") + 1] == "1800.0s"
+
+    def test_notify_non_custom_raises_value_error(self, client: PebbleCliClient):
+        """Test that non-custom notice types raise ValueError (not AssertionError)."""
+        with pytest.raises(ValueError, match="Only custom notices are supported"):
+            client.notify(ops.pebble.NoticeType.CHANGE_UPDATE, "some-key")
+
+    def test_get_warnings_empty(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """Test that the no-warnings case returns an empty list."""
+        mock_subprocess.run.return_value.stdout = "No warnings.\n"
+        assert client.get_warnings() == []
+
+        mock_subprocess.run.return_value.stdout = ""
+        assert client.get_warnings() == []
 
     def test_get_identities(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting identities."""


### PR DESCRIPTION
- get_warnings(): return [] for the no-warnings case instead of always raising NotImplementedError (it compared a CompletedProcess to a string).
- notify(): raise ValueError for non-custom notice types (was an assert, stripped under -O), and render repeat_after as a Pebble duration string (e.g. "1800.0s") rather than bare seconds.
- __init__: set PEBBLE_SOCKET alongside PEBBLE when socket_path is given, matching the documented behaviour.
- Ship a py.typed marker so downstream type checkers use Shimmer's types.
- Derive __version__ from installed package metadata (was hardcoded and out of sync with pyproject.toml).
- README: correct the PyPI install name to pebble-shimmer.
- CI: drop the always-false `matrix.test-type == 'integration'` guard so Pebble is actually installed and the integration tests run.

Adds unit tests for the get_warnings, notify, and PEBBLE_SOCKET behaviour.