### PR TITLE
fix: accept bare signal names in send_signal() (#15)

### DIFF
--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -290,9 +290,14 @@ class PebbleCliClient:
         if isinstance(sig, int):
             sig_name = signal.Signals(sig).name
         else:
-            if not hasattr(signal, sig):
+            # Accept both "SIGHUP" and the bare "HUP" form (any case).
+            full_name = sig.upper()
+            if not full_name.startswith("SIG"):
+                full_name = "SIG" + full_name
+            if full_name not in signal.Signals.__members__:
                 raise ValueError(f"Invalid signal name: {sig}")
-            sig_name = sig
+            sig_name = full_name
+        # Pebble's CLI expects the bare, uppercase signal name (e.g. "HUP").
         cmd = ["signal", sig_name[3:]] + service_list
         self._run_command(cmd)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -289,6 +289,29 @@ class TestPebbleCliClient:
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
 
+    def test_send_signal_bare_name(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """Test sending signal by bare name without the 'SIG' prefix."""
+        client.send_signal("HUP", ["service1"])
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
+
+    def test_send_signal_lowercase_name(
+        self, mock_subprocess: Mock, client: PebbleCliClient
+    ):
+        """Test sending signal by lowercase name."""
+        client.send_signal("sighup", ["service1"])
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
+
+    def test_send_signal_invalid_name(
+        self, mock_subprocess: Mock, client: PebbleCliClient
+    ):
+        """Test that an invalid signal name raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid signal name"):
+            client.send_signal("NOTASIGNAL", ["service1"])
+
     def test_send_signal_int(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test sending signal by number."""
         import signal


### PR DESCRIPTION
## Summary

`send_signal()` only accepted the `"SIGHUP"` form for string signals. A bare `"HUP"` failed the `hasattr(signal, sig)` check and raised `ValueError`, and the `sig_name[3:]` slice would silently mangle any non-prefixed name. `ops.pebble.Client.send_signal` is more permissive, so this was a behavioural gap.

## Changes

- Normalize string signals: uppercase, prepend `"SIG"` if absent, then validate against `signal.Signals` before stripping the prefix for Pebble's CLI (which expects the bare uppercase name, e.g. `HUP`).
- Now accepts `"HUP"`, `"SIGHUP"`, and lowercase variants; still rejects unknown names with `ValueError`.
- Added unit tests for the bare-name, lowercase, and invalid-name forms (the int form was already tested).

Fixes #15

## Test plan

- `uv run --extra dev pytest tests/unit/` — all 64 tests pass
- `uv run --extra dev ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)