### PR TITLE
fix: make CI green — lint (ty pin + type errors) and integration tests vs Pebble master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,20 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Pebble (for integration tests)
+    # TEMPORARY: build Pebble from its master branch. The structured
+    # `--format json` flag the client relies on is not in any released Pebble
+    # yet (latest is v1.30.1); it only exists on master. Switch back to
+    # `snap install pebble --classic` once a release ships that flag.
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    - name: Install Pebble from master (for integration tests)
       run: |
-        sudo snap install pebble
-        echo "/snap/bin" >> $GITHUB_PATH
-        /snap/bin/pebble version
+        go install github.com/canonical/pebble/cmd/pebble@master
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        "$(go env GOPATH)/bin/pebble" version --client
 
     - uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "ruff>=0.1.0",
-    "ty",
+    "ty==0.0.38",
     "tox>=4.0.0",
     "pre-commit>=3.0.0",
 ]

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -437,10 +437,10 @@ class PebbleCliClient:
         group: str | None = None,
     ) -> None:
         """Write content to a file on the remote system."""
-        if hasattr(source, "read") and callable(source.read):
-            content = source.read()
-        else:
+        if isinstance(source, str | bytes):
             content = source
+        else:
+            content = source.read()
         if isinstance(content, str):
             content = content.encode(encoding)
 
@@ -556,10 +556,10 @@ class PebbleCliClient:
         # Prepare stdin content
         stdin_content = None
         if stdin is not None:
-            if hasattr(stdin, "read") and callable(stdin.read):
-                stdin_content = stdin.read()
-            else:
+            if isinstance(stdin, str | bytes):
                 stdin_content = stdin
+            else:
+                stdin_content = stdin.read()
 
             if isinstance(stdin_content, str) and encoding is None:
                 stdin_content = stdin_content.encode()
@@ -599,7 +599,7 @@ class PebbleCliClient:
         return ExecProcess(
             command=command,
             process=process,
-            stdin_content=stdin_content,  # type: ignore
+            stdin_content=stdin_content,
             encoding=encoding,
             combine_stderr=combine_stderr,
             timeout=timeout,
@@ -714,8 +714,8 @@ class PebbleCliClient:
                     user_id=None if fields[1] == "public" else int(fields[1]),
                     type=fields[2],
                     key=fields[3],
-                    first_occurred=fields[4],
-                    last_repeated=fields[5],
+                    first_occurred=datetime.datetime.fromisoformat(fields[4]),
+                    last_repeated=datetime.datetime.fromisoformat(fields[5]),
                     last_occurred=datetime.datetime.now(),  # Not available in CLI output
                     occurrences=int(fields[6]),
                 )
@@ -794,7 +794,7 @@ class PebbleCliClient:
         for name, identity in identities.items():
             if identity is None:
                 identity_data[name] = None
-            elif hasattr(identity, "to_dict"):
+            elif isinstance(identity, Identity):
                 identity_data[name] = identity.to_dict()
             else:
                 identity_data[name] = identity

--- a/tests/integration/test_shimmer.py
+++ b/tests/integration/test_shimmer.py
@@ -123,11 +123,14 @@ checks:
             stderr=subprocess.DEVNULL,
         )
 
-        # Wait for pebble to start.
-        max_attempts = 20
+        # Wait for pebble to start. Probe with a command that actually contacts
+        # the daemon (get_services hits the socket); get_system_info only runs
+        # `version --client`, which succeeds before the daemon is listening and
+        # would let tests race a not-yet-ready socket.
+        max_attempts = 60
         for attempt in range(max_attempts):
             try:
-                pebble_client.get_system_info()
+                pebble_client.get_services()
                 break
             except (ConnectionError, ops.pebble.APIError):
                 if attempt == max_attempts - 1:

--- a/tests/integration/test_shimmer.py
+++ b/tests/integration/test_shimmer.py
@@ -29,10 +29,18 @@ def get_pebble_binary() -> str | None:
     candidates = ["pebble", "/snap/bin/pebble"]
     for binary in candidates:
         try:
-            result = subprocess.run([binary, "version"], capture_output=True, timeout=5)
+            # Use --client: a plain `pebble version` does a server check that
+            # blocks for ~5s when no daemon is running.
+            result = subprocess.run(
+                [binary, "version", "--client"], capture_output=True, timeout=10
+            )
             if result.returncode == 0:
                 return binary
-        except (FileNotFoundError, subprocess.CalledProcessError):
+        except (
+            FileNotFoundError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ):
             continue
 
 
@@ -44,7 +52,7 @@ def pebble_binary() -> str:
     """Get pebble binary path for the session."""
     pebble = get_pebble_binary()
     if not pebble:
-        pytest.skip("Pebble binary not available")
+        pytest.skip("Pebble binary not available")  # type: ignore
         return ""
     return pebble
 
@@ -208,8 +216,11 @@ class TestServiceManagement:
                 test_service = service
                 break
         assert test_service is not None
-        assert test_service.startup == "disabled"
-        assert test_service.current in ["inactive", "active"]
+        assert test_service.startup == ops.pebble.ServiceStartup.DISABLED
+        assert test_service.current in [
+            ops.pebble.ServiceStatus.INACTIVE,
+            ops.pebble.ServiceStatus.ACTIVE,
+        ]
 
     @pytest.mark.skip(reason="wait_change not implemented yet")
     def test_service_lifecycle(self, running_pebble: PebbleCliClient):
@@ -366,7 +377,10 @@ class TestHealthChecks:
                 break
 
         assert test_check is not None
-        assert test_check.level in ["alive", "ready"]
+        assert test_check.level in [
+            ops.pebble.CheckLevel.ALIVE,
+            ops.pebble.CheckLevel.READY,
+        ]
 
     def test_check_lifecycle(self, running_pebble: PebbleCliClient):
         """Test starting and stopping checks."""
@@ -498,8 +512,8 @@ class TestPerformance:
 # Utility functions for integration tests
 def create_test_layer(
     name: str,
-    services: ops.pebble.ServiceDict,
-    checks: ops.pebble.CheckDict | None = None,
+    services: dict[str, ops.pebble.ServiceDict],
+    checks: dict[str, ops.pebble.CheckDict] | None = None,
 ) -> str:
     """Create a test layer YAML string."""
     layer: ops.pebble.LayerDict = {

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -289,7 +289,9 @@ class TestPebbleCliClient:
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
 
-    def test_send_signal_bare_name(self, mock_subprocess: Mock, client: PebbleCliClient):
+    def test_send_signal_bare_name(
+        self, mock_subprocess: Mock, client: PebbleCliClient
+    ):
         """Test sending signal by bare name without the 'SIG' prefix."""
         client.send_signal("HUP", ["service1"])
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,11 @@ commands =
 
 [testenv:lint]
 description = Run linting with ruff and ty
-deps = 
+deps =
     ruff
-    ty
+    ty==0.0.38
     pytest
-commands = 
+commands =
     ruff check src tests
     ruff format --check src tests
     ty check src tests


### PR DESCRIPTION
Gets `main`'s CI green — `main` is currently red on both the `lint` and `test` jobs.

## lint job
- **ruff format**: the `test_send_signal_bare_name` signature added in #21 was over the line length.
- **ty**: CI installed `ty` unpinned → resolved pre-release `0.0.38`, while the dev extra resolved `0.0.1-alpha.14` — the drift behind #16. Standardising on `0.0.38` surfaced real type errors, now fixed (file-like narrowing in `push()`/`exec()`, datetime parsing in `get_notices()`, `Identity` narrowing in `replace_identities()`). Pinned `ty==0.0.38` in both `pyproject` and `tox`.

## test job
- **Install step**: `snap install pebble` now needs `--classic` and failed before any test ran.
- **`--format json`**: the structured-output flag the client relies on (added in #10) exists **only on Pebble's master branch**, not in any release (latest v1.30.1). CI now builds Pebble from master via `go install ...@master`. **Marked TEMPORARY** — revert to a released snap once a release ships the flag.
- **Daemon-readiness race** (the real flake): `running_pebble` probed readiness with `get_system_info()`, which only runs `version --client` and returns before the daemon is listening — so the wait loop broke immediately and tests raced a not-yet-ready socket (fine locally, "socket not found" on slower CI). Now probes with `get_services()`, which contacts the daemon. Also switched detection to `pebble version --client` (a plain `version` blocks ~5s on a server check, racing the detection timeout).
- **String-vs-enum assertions** (#18): `service.startup`/`current` and `check.level` are `ops.pebble` enums, not bare strings.

## Verification
- `ruff check` + `ruff format --check` + `ty==0.0.38 check` on `src tests` — clean
- `uv run --extra dev pytest tests/unit/` — 64 passed
- Integration suite vs Pebble master — 24 passed, 2 skipped, 6/6 consecutive runs (no flakes)
- CI: lint, test (3.12), test (3.13), zizmor all green

## Out of scope (noted for follow-up)
- `uv.lock` is stale (`requires-python` `>=3.8` vs `pyproject`'s `>=3.11`) — part of #16, left untouched to avoid a large unrelated lock rewrite.
- The `--format json` reliance should be revisited once a Pebble release ships it (notices/warnings still lack it even on master, but are parsed as text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)