### PR TITLE
fix: drain pipes in ExecProcess.wait() to avoid deadlock (#13)

### DIFF
--- a/src/shimmer/_process.py
+++ b/src/shimmer/_process.py
@@ -43,14 +43,24 @@ class ExecProcess:
         if self._finished:
             return
 
+        # Use communicate() rather than wait() so that the stdout/stderr pipes
+        # are drained concurrently with the process running. Calling wait()
+        # before reading the pipes can deadlock: the child blocks writing once
+        # the OS pipe buffer (~64KB) fills, while the parent blocks in wait().
+        # communicate() also feeds stdin_content, which a plain wait() never
+        # does (a process reading stdin would otherwise hang).
         try:
-            self._process.wait(timeout=self._timeout)
+            stdout_data, stderr_data = self._process.communicate(
+                input=self._stdin_content, timeout=self._timeout
+            )
         except subprocess.TimeoutExpired as e:
             self._process.terminate()
             try:
                 self._process.wait(timeout=self._timeout)
             except subprocess.TimeoutExpired:
                 self._process.kill()
+            # Drain the pipes so the killed child can be reaped cleanly.
+            self._process.communicate()
             raise ops.pebble.TimeoutError(
                 f"Command {self.command} timed out after {self._timeout}s"
             ) from e
@@ -59,24 +69,17 @@ class ExecProcess:
         if self._process.returncode == 0:
             return
 
-        stdout_data = ""
-        stderr_data = ""
-
-        if self._process.stdout:
-            stdout_data = self._process.stdout.read()
-            if isinstance(stdout_data, bytes) and self._encoding:
+        if self._encoding:
+            if isinstance(stdout_data, bytes):
                 stdout_data = stdout_data.decode(self._encoding)
-
-        if self._process.stderr:
-            stderr_data = self._process.stderr.read()
-            if isinstance(stderr_data, bytes) and self._encoding:
+            if isinstance(stderr_data, bytes):
                 stderr_data = stderr_data.decode(self._encoding)
 
         raise ops.pebble.ExecError(
             command=self.command,
             exit_code=self._process.returncode,
-            stdout=stdout_data,  # type: ignore
-            stderr=stderr_data,  # type: ignore
+            stdout=stdout_data or "",
+            stderr=stderr_data or "",
         )
 
     def wait_output(self) -> tuple[str | bytes, str | bytes | None]:

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 import ops
@@ -45,7 +46,7 @@ class TestPebbleCliExecProcess:
 
     def test_wait_success(self, mock_process: Mock):
         """Test successful process wait."""
-        mock_process.wait.return_value = None
+        mock_process.communicate.return_value = ("", "")
         mock_process.returncode = 0
 
         exec_process = ExecProcess(
@@ -54,16 +55,15 @@ class TestPebbleCliExecProcess:
         )
 
         exec_process.wait()  # Should not raise
-        mock_process.wait.assert_called_once_with(timeout=None)
+        # wait() must drain the pipes (via communicate) rather than just
+        # wait() so it can't deadlock on large output.
+        mock_process.communicate.assert_called_once_with(input=None, timeout=None)
+        mock_process.wait.assert_not_called()
 
     def test_wait_failure(self, mock_process: Mock):
         """Test process wait with non-zero exit code."""
-        mock_process.wait.return_value = None
+        mock_process.communicate.return_value = ("stdout", "stderr")
         mock_process.returncode = 1
-        mock_process.stdout = Mock()
-        mock_process.stderr = Mock()
-        mock_process.stdout.read.return_value = "stdout"
-        mock_process.stderr.read.return_value = "stderr"
 
         exec_process = ExecProcess(
             command=["false"],
@@ -76,10 +76,32 @@ class TestPebbleCliExecProcess:
         assert isinstance(exc_info.value, ops.pebble.ExecError)
         assert exc_info.value.exit_code == 1
         assert exc_info.value.command == ["false"]
+        assert exc_info.value.stdout == "stdout"
+        assert exc_info.value.stderr == "stderr"
+
+    def test_wait_feeds_stdin(self, mock_process: Mock):
+        """wait() should feed stdin_content to the process."""
+        mock_process.communicate.return_value = ("", "")
+        mock_process.returncode = 0
+
+        exec_process = ExecProcess(
+            command=["cat"],
+            process=mock_process,
+            stdin_content="hello",
+        )
+
+        exec_process.wait()
+
+        mock_process.communicate.assert_called_once_with(
+            input="hello", timeout=None
+        )
 
     def test_wait_timeout(self, mock_process: Mock):
         """Test process wait timeout."""
-        mock_process.wait.side_effect = subprocess.TimeoutExpired("cmd", 5.0)
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired("cmd", 5.0),
+            ("", ""),
+        ]
 
         exec_process = ExecProcess(
             command=["sleep", "10"],
@@ -163,6 +185,57 @@ class TestPebbleCliExecProcess:
         exec_process.send_signal(signal.SIGTERM)
 
         mock_process.send_signal.assert_called_once_with(signal.SIGTERM)
+
+    def test_wait_large_output_no_deadlock(self):
+        """wait() must not deadlock when output exceeds the OS pipe buffer.
+
+        Regression test: a child writing more than the pipe buffer (~64KB)
+        to stdout before exiting will block on write while the parent blocks
+        in wait(), unless the pipes are drained concurrently.
+        """
+        # Emit ~1MB to stdout, well over any pipe buffer, then exit 0.
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.stdout.write('x' * (1024 * 1024))"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        exec_process = ExecProcess(
+            command=["big-output"],
+            process=process,
+            timeout=30.0,
+        )
+
+        # Without draining the pipes this call would hang until the timeout.
+        exec_process.wait()
+
+        assert process.returncode == 0
+
+    def test_wait_large_output_failure_raises(self):
+        """wait() drains large output and still reports ExecError on failure."""
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('e' * (1024 * 1024)); sys.exit(3)",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        exec_process = ExecProcess(
+            command=["big-error"],
+            process=process,
+            timeout=30.0,
+        )
+
+        with pytest.raises(ops.pebble.ExecError) as exc_info:
+            exec_process.wait()
+
+        assert exc_info.value.exit_code == 3
+        assert len(exc_info.value.stderr) == 1024 * 1024
 
     @patch("shimmer._process.subprocess.Popen")
     def test_exec_process_edge_cases(self, mock_popen: Mock, client: PebbleCliClient):


### PR DESCRIPTION
Fixes #13.

## Problem
`ExecProcess.wait()` called `subprocess.wait()` and only read `stdout`/`stderr` afterward. When those streams are pipes (the default when the caller doesn't supply their own file objects), a child emitting more than the OS pipe buffer (~64KB) before exiting blocks on write while the parent blocks in `wait()` — a classic subprocess deadlock. Any exec producing >64KB of output before exiting could hang.

## Fix
Reimplement `wait()` in terms of `communicate()`, which drains the pipes concurrently with the process running. This also feeds `stdin_content` — which the old `wait()` never did, hanging any process that reads stdin — and keeps the captured output for the `ExecError` raised on non-zero exit. The timeout path now also drains the pipes after killing the child so it can be reaped cleanly.

## Tests
- Added two regression tests that exec a real subprocess emitting ~1MB to stdout / stderr and call `wait()`; these would hang under the old implementation.
- Updated the mocked `wait` tests for the `communicate()` path and added a test asserting stdin is fed.

## Verification
- 67 unit tests pass (`ruff` clean, `ty` type check passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)