### PR TITLE
docs: backfill changelog, fix stale README, add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+Guidance for AI agents (and humans) working in this repo. Keep it short and current.
+
+## What this project is
+
+Shimmer provides `PebbleCliClient`, a **100% drop-in replacement for
+`ops.pebble.Client`** that talks to Pebble via the **CLI** instead of the unix
+socket (for environments with restricted socket access, e.g. a Rock or Juju
+container).
+
+**Prime directive: preserve API parity with `ops.pebble.Client`.** Method
+signatures, return types, and raised exceptions must match what `ops` exposes.
+When in doubt, check the installed `ops.pebble` and mirror it. Parity is
+exercised by `tests/integration/test_parity.py`.
+
+## Keep the CHANGELOG current
+
+`CHANGELOG.md` is curated and **must be updated in the same change as any
+user-facing behaviour change.** Entries are grouped under a dated `# YYYY-MM-DD`
+header, split into `Features:` and `Bug fixes and packaging:`.
+
+- **Include:** new/changed/removed library behaviour, exceptions, packaging
+  (e.g. `py.typed`), and anything that affects published artifacts.
+- **Exclude:** CI/tooling-only changes, lint/format churn, and dependency
+  bumps (Dependabot action/lib bumps do **not** belong in the changelog).
+- Describe the change from the **user's** perspective, not the commit's.
+
+If you land a fix and the changelog wasn't touched, that's a miss — add it.
+
+## Development workflow
+
+- Use **`uv`**. `uv sync --extra dev` for a dev environment.
+- **`ty`** is the type checker (not pyright/mypy). **`ruff`** does lint +
+  format. Both are pinned in the `dev` extra and run through `tox`/`uv run`, so
+  every environment uses identical versions.
+- Common commands:
+  - `tox -e lint` — ruff check + ruff format --check + ty check
+  - `tox -e format` — apply ruff formatting
+  - `tox -e unit` — unit tests (no Pebble needed)
+  - `tox -e integration` — integration tests (**requires a `pebble` binary**)
+- `pre-commit` hooks run the same pinned tools via `uv run`; install with
+  `pre-commit install`.
+
+## Testing notes
+
+- Unit tests (`tests/unit/`) mock the CLI and need no Pebble.
+- Integration tests (`tests/integration/`) shell out to a real `pebble` binary
+  and assert parity against the socket client.
+- **Temporary:** CI builds Pebble from `master` because the structured
+  `--format json` output the client relies on for some read commands isn't in a
+  released Pebble yet. Switch back to `snap install pebble` once a release ships
+  it (see the note in `.github/workflows/ci.yaml`).
+
+## CI, merging, and supply chain
+
+- `main` is protected: changes go via **PR**, squash-merge only, and must pass
+  `lint`, `test (3.12)`, `test (3.13)`, and `zizmor`. There is no admin bypass.
+- Commit messages follow **Conventional Commits** (`fix:`, `feat:`,
+  `build(deps):`, `chore:`, `docs:`).
+- GitHub Actions are **SHA-pinned by default**; `actions/*`, `github/*` and
+  `pypa/*` are allowed to use tag/ref pins (see `.github/zizmor.yml`). zizmor
+  enforces this — its config file must be named `zizmor.yml` (it does not
+  auto-discover `.yaml`).
+- Releases publish to PyPI via OIDC trusted publishing in a gated environment,
+  with build-provenance + SBOM attestations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Bug fixes and packaging:
   notice types, and renders `repeat_after` as a valid Pebble duration string.
 - `socket_path` now also sets the `PEBBLE_SOCKET` environment variable, as
   documented.
+- `get_notice()` and `get_notices()` now return correctly-typed `Notice`
+  objects (real `last_occurred`/`last_data`/`expire_after`) parsed from
+  Pebble's per-ID YAML. `get_notice(id)` previously returned the wrong notice
+  or raised `IndexError`.
+- `send_signal()` accepts bare signal names (e.g. `"HUP"`) in addition to the
+  `"SIGHUP"` form, matching `ops.pebble.Client`; invalid names raise
+  `ValueError`.
+- `ExecProcess.wait()` no longer deadlocks when a process emits more than the
+  OS pipe buffer (~64KB) before exiting, and now feeds `stdin`. It is
+  reimplemented in terms of `communicate()`.
 - Ship a `py.typed` marker so downstream type checkers use Shimmer's types.
 - `__version__` is derived from the installed package metadata.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ client = PebbleCliClient(socket_path="/custom/path/.pebble.socket")
 ### Error Handling
 
 ```python
-from shimmer import APIError, ConnectionError, TimeoutError
+from ops.pebble import APIError, ConnectionError, TimeoutError
 
 try:
     client.start_services(["nonexistent"])
@@ -135,11 +135,9 @@ Other minor limitations:
 
 - `replan_services()`, `start_services()`, `stop_services()`, and `restart_services()` are only able to return the change ID if no timeout is set.
 - `notify()` only supports custom notices.
-- `get_notices()` cannot include the `last_occurred`, `last_data`, `repeat_after`, or `expire_after` fields
 - `autostart_services()` is an alias for `replan()` (possibly we could fix this by getting the current state?)
-- `wait_change()` is yet to be implemented
-- `ack_warnings()` is yet to be implemented
-- `get_warnings()` is only implemented for the 'no warnings' case
+- `ack_warnings()` is yet to be implemented.
+- `get_warnings()` is only implemented for the 'no warnings' case; parsing a non-empty warnings list raises `NotImplementedError`.
 
 `get_services()`, `get_checks()`, `list_files()`, `get_changes()`,
 `get_change()`, and `get_identities()` use Pebble's structured `--format json`


### PR DESCRIPTION
## CHANGELOG
Backfills three user-facing fixes that landed today but weren't recorded under the `2026-05-22` entry:
- `get_notice()`/`get_notices()` now return correctly-typed notices (#11)
- `send_signal()` accepts bare signal names (#21)
- `ExecProcess.wait()` no longer deadlocks on large output (#13)

(Action/dependency bumps and CI-only commits are intentionally excluded — they're not user-facing.)

## README
- Remove **"`wait_change()` is yet to be implemented"** — it *is* implemented, and the examples already call it.
- Remove the **`get_notices()` missing-fields** limitation — fixed by #11.
- The error-handling example imported `APIError`/`ConnectionError`/`TimeoutError` from `shimmer`, which doesn't re-export them → would `ImportError`. Now imports from `ops.pebble`.

## AGENTS.md (+ `CLAUDE.md` symlink)
Project conventions for agents/contributors, including the rule to **keep `CHANGELOG.md` current with every user-facing change**, plus dev workflow (uv/tox, `ty` for types), testing notes, and the merge/supply-chain conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)