### PR TITLE
feat: re-export pebble exceptions from shimmer top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Bug fixes and packaging:
   notice types, and renders `repeat_after` as a valid Pebble duration string.
 - `socket_path` now also sets the `PEBBLE_SOCKET` environment variable, as
   documented.
+- The pebble exception types (`Error`, `APIError`, `ChangeError`,
+  `ConnectionError`, `ExecError`, `PathError`, `ProtocolError`, `TimeoutError`)
+  can now be imported directly from `shimmer` (e.g. `from shimmer import
+  APIError`); previously they had to be imported from `ops.pebble`.
 - `get_notice()` and `get_notices()` now return correctly-typed `Notice`
   objects (real `last_occurred`/`last_data`/`expire_after`) parsed from
   Pebble's per-ID YAML. `get_notice(id)` previously returned the wrong notice

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ client = PebbleCliClient(socket_path="/custom/path/.pebble.socket")
 ### Error Handling
 
 ```python
-from ops.pebble import APIError, ConnectionError, TimeoutError
+from shimmer import APIError, ConnectionError, TimeoutError
 
 try:
     client.start_services(["nonexistent"])

--- a/src/shimmer/__init__.py
+++ b/src/shimmer/__init__.py
@@ -2,11 +2,37 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+# Re-export the pebble exception hierarchy so callers can catch shimmer errors
+# without also importing ops.pebble (shimmer raises these same types).
+from ops.pebble import (
+    APIError,
+    ChangeError,
+    ConnectionError,
+    Error,
+    ExecError,
+    PathError,
+    ProtocolError,
+    TimeoutError,
+)
+
 from ._client import PebbleCliClient
 from ._process import ExecProcess
 from ._protocol import PebbleClientProtocol
 
-__all__ = ["PebbleCliClient", "ExecProcess", "PebbleClientProtocol"]
+__all__ = [
+    "PebbleCliClient",
+    "ExecProcess",
+    "PebbleClientProtocol",
+    # Re-exported ops.pebble exceptions.
+    "Error",
+    "APIError",
+    "ChangeError",
+    "ConnectionError",
+    "ExecError",
+    "PathError",
+    "ProtocolError",
+    "TimeoutError",
+]
 
 try:
     __version__ = version("pebble-shimmer")

--- a/tests/unit/test_exports.py
+++ b/tests/unit/test_exports.py
@@ -1,0 +1,26 @@
+"""Shimmer re-exports the ops.pebble exception hierarchy from its top level."""
+
+import ops.pebble
+
+import shimmer
+
+EXCEPTIONS = [
+    "Error",
+    "APIError",
+    "ChangeError",
+    "ConnectionError",
+    "ExecError",
+    "PathError",
+    "ProtocolError",
+    "TimeoutError",
+]
+
+
+def test_exceptions_are_reexported_from_ops_pebble():
+    for name in EXCEPTIONS:
+        assert getattr(shimmer, name) is getattr(ops.pebble, name)
+
+
+def test_exceptions_are_listed_in_all():
+    for name in EXCEPTIONS:
+        assert name in shimmer.__all__


### PR DESCRIPTION
shimmer raises the `ops.pebble` exception types but didn't re-export them, so `from shimmer import APIError` raised `ImportError` and callers had to reach into `ops.pebble`. For a drop-in replacement, the exceptions should be catchable from `shimmer` directly.

- Re-export the full exception hierarchy from `shimmer/__init__.py`: `Error`, `APIError`, `ChangeError`, `ConnectionError`, `ExecError`, `PathError`, `ProtocolError`, `TimeoutError` (added to `__all__`).
- Restore the README error-handling example to `from shimmer import ...` (PR #34 had pointed it at `ops.pebble` as a stopgap because the re-export didn't exist).
- Add `tests/unit/test_exports.py` asserting the re-exports are the *same objects* as `ops.pebble`'s and are listed in `__all__`.
- CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)