### PR TITLE
test: twin-daemon parity suite + ops.pebble.Client compatibility fixes

### DIFF
--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -17,8 +17,8 @@ import signal
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterable
-from typing import Any, BinaryIO, TextIO, overload
+from collections.abc import Iterable, Mapping
+from typing import Any, BinaryIO, NoReturn, TextIO, overload
 
 import yaml
 
@@ -30,6 +30,7 @@ from ops.pebble import (
     ChangeState,
     CheckInfo,
     CheckLevel,
+    CheckStatus,
     ConnectionError,
     FileInfo,
     Identity,
@@ -38,8 +39,10 @@ from ops.pebble import (
     Notice,
     NoticesUsers,
     NoticeType,
+    PathError,
     Plan,
     ServiceInfo,
+    ServiceStartup,
     SystemInfo,
     TimeoutError,
     Warning,
@@ -179,6 +182,21 @@ class PebbleCliClient:
         result = self._run_command(["plan"])
         return Plan(yaml.safe_load(result.stdout))
 
+    def _run_change_command(self, cmd: list[str], timeout: float) -> ChangeID:
+        """Run a change-producing command and return its real change ID.
+
+        ``pebble`` only prints the change ID when invoked with ``--no-wait``
+        (when it waits, it prints nothing). To match ops.pebble.Client -- which
+        always returns the real change ID -- we always pass ``--no-wait`` to
+        capture the ID, then wait for the change ourselves when the caller asked
+        us to (``timeout`` greater than zero).
+        """
+        result = self._run_command([*cmd, "--no-wait"])
+        change_id = ChangeID(result.stdout.strip())
+        if timeout:
+            self.wait_change(change_id, timeout=timeout)
+        return change_id
+
     def replan_services(
         self,
         *,
@@ -188,16 +206,7 @@ class PebbleCliClient:
         """Replan services."""
         if delay is not None:
             time.sleep(delay)
-
-        cmd = ["replan"]
-        if timeout == 0:
-            cmd.append("--no-wait")
-
-        result = self._run_command(cmd)
-        # We only get the change ID if using --no-wait.
-        if timeout == 0:
-            return ChangeID(result.stdout.strip())
-        return ChangeID("?")
+        return self._run_change_command(["replan"], timeout)
 
     def get_services(self, names: Iterable[str] | None = None) -> list[ServiceInfo]:
         """Get service status information."""
@@ -223,16 +232,7 @@ class PebbleCliClient:
         service_list = list(services)
         if not service_list:
             raise ValueError("services list cannot be empty")
-
-        cmd = ["start"] + service_list
-        if timeout == 0:
-            cmd.append("--no-wait")
-
-        result = self._run_command(cmd)
-        # We only get the change ID if using --no-wait.
-        if timeout == 0:
-            return ChangeID(result.stdout.strip())
-        return ChangeID("?")
+        return self._run_change_command(["start", *service_list], timeout)
 
     def stop_services(
         self,
@@ -248,16 +248,7 @@ class PebbleCliClient:
         service_list = list(services)
         if not service_list:
             raise ValueError("services list cannot be empty")
-
-        cmd = ["stop"] + service_list
-        if timeout == 0:
-            cmd.append("--no-wait")
-
-        result = self._run_command(cmd)
-        # We only get the change ID if using --no-wait.
-        if timeout == 0:
-            return ChangeID(result.stdout.strip())
-        return ChangeID("?")
+        return self._run_change_command(["stop", *service_list], timeout)
 
     def restart_services(
         self,
@@ -273,16 +264,7 @@ class PebbleCliClient:
         service_list = list(services)
         if not service_list:
             raise ValueError("services list cannot be empty")
-
-        cmd = ["restart"] + service_list
-        if timeout == 0:
-            cmd.append("--no-wait")
-
-        result = self._run_command(cmd)
-        # We only get the change ID if using --no-wait.
-        if timeout == 0:
-            return ChangeID(result.stdout.strip())
-        return ChangeID("?")
+        return self._run_change_command(["restart", *service_list], timeout)
 
     def autostart_services(
         self,
@@ -291,7 +273,24 @@ class PebbleCliClient:
         delay: float | None = None,
     ) -> ChangeID:
         """Start all startup-enabled services."""
-        # There's no direct CLI equivalent, use replan which starts enabled services.
+        # There's no direct CLI equivalent; `replan` starts enabled services.
+        # ops.pebble.Client's autostart raises "no default services" when no
+        # service is startup-enabled, but `replan` succeeds silently in that
+        # case -- so reproduce the error to stay API-compatible.
+        plan = self.get_plan()
+        enabled = [
+            name
+            for name, service in plan.services.items()
+            if service.startup == ServiceStartup.ENABLED.value
+        ]
+        if not enabled:
+            message = "no default services"
+            raise APIError(
+                body={"message": message},
+                code=400,
+                status="Bad Request",
+                message=message,
+            )
         return self.replan_services(timeout=timeout, delay=delay)
 
     def send_signal(
@@ -335,31 +334,71 @@ class PebbleCliClient:
             return []
         return [CheckInfo.from_dict(check) for check in data["checks"].values()]
 
+    def _inactive_checks(self, names: list[str]) -> set[str]:
+        """Names (from ``names``) whose check is currently inactive."""
+        return {
+            check.name
+            for check in self.get_checks(names=names)
+            if check.status == CheckStatus.INACTIVE
+        }
+
     def start_checks(self, checks: Iterable[str]) -> list[str]:
-        """Start checks."""
+        """Start checks, returning those whose state actually changed.
+
+        Like ops.pebble.Client, checks that were already running are not
+        included in the result.
+        """
         check_list = list(checks)
         if not check_list:
             raise ValueError("checks list cannot be empty")
 
-        cmd = ["start-checks"] + check_list
-        self._run_command(cmd)
-
-        # Return list of started checks (assume all were started)
-        return check_list
+        # Only inactive checks transition to running, so they are the ones the
+        # API reports as changed.
+        was_inactive = self._inactive_checks(check_list)
+        self._run_command(["start-checks", *check_list])
+        return [name for name in check_list if name in was_inactive]
 
     def stop_checks(self, checks: Iterable[str]) -> list[str]:
-        """Stop checks."""
+        """Stop checks, returning those whose state actually changed.
+
+        Like ops.pebble.Client, checks that were already inactive are not
+        included in the result.
+        """
         check_list = list(checks)
         if not check_list:
             raise ValueError("checks list cannot be empty")
 
-        cmd = ["stop-checks"] + check_list
-        self._run_command(cmd)
-
-        # Return list of stopped checks (assume all were stopped)
-        return check_list
+        # Only running checks transition to inactive, so they are the ones the
+        # API reports as changed.
+        was_inactive = self._inactive_checks(check_list)
+        self._run_command(["stop-checks", *check_list])
+        return [name for name in check_list if name not in was_inactive]
 
     # File operations
+    @staticmethod
+    def _raise_path_error(error: APIError) -> NoReturn:
+        """Translate a file-operation APIError into a PathError.
+
+        ops.pebble.Client raises PathError (not APIError) when a file operation
+        fails because of the path itself. We classify the CLI's error text into
+        the same ``kind`` values the API uses; anything that isn't a path error
+        (e.g. a connection failure) is re-raised unchanged.
+        """
+        text = (error.message or "").lower()
+        if "no such file" in text or "does not exist" in text:
+            kind = "not-found"
+        elif "permission denied" in text:
+            kind = "permission-denied"
+        elif (
+            "not a directory" in text
+            or "is a directory" in text
+            or "already exists" in text
+        ):
+            kind = "generic"
+        else:
+            raise error
+        raise PathError(kind, error.message) from error
+
     def list_files(
         self,
         path: str,
@@ -372,7 +411,10 @@ class PebbleCliClient:
         if itself:
             cmd.append("-d")
 
-        data = self._run_json(cmd)
+        try:
+            data = self._run_json(cmd)
+        except APIError as e:
+            self._raise_path_error(e)
         files = [FileInfo.from_dict(entry) for entry in (data or {}).get("files", [])]
         # ``pattern`` matches against entry names; Pebble's ls glob support only
         # applies to the final path element, so filter here to match the
@@ -407,7 +449,10 @@ class PebbleCliClient:
         elif group_id is not None:
             cmd.extend(["--gid", str(group_id)])
 
-        self._run_command(cmd)
+        try:
+            self._run_command(cmd)
+        except APIError as e:
+            self._raise_path_error(e)
 
     def remove_path(self, path: str, *, recursive: bool = False) -> None:
         """Remove a file or directory."""
@@ -415,7 +460,10 @@ class PebbleCliClient:
         if recursive:
             cmd.append("--recursive")
 
-        self._run_command(cmd)
+        try:
+            self._run_command(cmd)
+        except APIError as e:
+            self._raise_path_error(e)
 
     @overload
     def pull(self, path: str, *, encoding: None) -> BinaryIO: ...
@@ -433,7 +481,10 @@ class PebbleCliClient:
         with tempfile.NamedTemporaryFile() as tmp_file:
             tmp_file.close()
             cmd = ["pull", path, tmp_file.name]
-            self._run_command(cmd)
+            try:
+                self._run_command(cmd)
+            except APIError as e:
+                self._raise_path_error(e)
             if encoding is None:
                 with open(tmp_file.name, "rb") as tmp_file:
                     return io.BytesIO(tmp_file.read())
@@ -479,7 +530,10 @@ class PebbleCliClient:
             tmp_file.write(content)
             tmp_file.flush()
             cmd.insert(1, tmp_file.name)
-            self._run_command(cmd)
+            try:
+                self._run_command(cmd)
+            except APIError as e:
+                self._raise_path_error(e)
 
     # Exec I/O is str if encoding is provided (the default)
     @overload
@@ -641,10 +695,14 @@ class PebbleCliClient:
 
     def get_changes(
         self,
-        select: ChangeState | None = None,
+        select: ChangeState = ChangeState.IN_PROGRESS,
         service: str | None = None,
     ) -> list[Change]:
-        """Get list of changes."""
+        """Get list of changes.
+
+        ``select`` defaults to ``ChangeState.IN_PROGRESS`` to match
+        ops.pebble.Client (which returns only in-progress changes by default).
+        """
         cmd = ["changes"]
         if service:
             cmd.append(service)
@@ -664,12 +722,25 @@ class PebbleCliClient:
     def wait_change(
         self,
         change_id: ChangeID,
-        *,
-        timeout: float | None = None,
+        timeout: float | None = 30.0,
         delay: float = 0.1,
     ) -> Change:
-        """Wait for a change to be ready."""
-        raise NotImplementedError
+        """Wait for a change to be ready, polling until it completes.
+
+        Mirrors ops.pebble.Client.wait_change: returns the ready change, or
+        raises ops.pebble.TimeoutError if it is not ready within ``timeout``
+        seconds (``timeout=None`` waits indefinitely).
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            change = self.get_change(change_id)
+            if change.ready:
+                return change
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"timed out waiting for change {change_id} ({timeout} seconds)"
+                )
+            time.sleep(delay)
 
     def get_notices(
         self,
@@ -749,27 +820,32 @@ class PebbleCliClient:
         # The output looks like: "Recorded notice 38"
         return result.stdout.strip().split()[-1]
 
+    # Warnings are deprecated in Pebble: the warnings API endpoint has been
+    # removed (warnings are now surfaced as notices), and the `pebble okay` CLI
+    # has stateful, timestamp-free semantics that cannot reproduce
+    # ops.pebble.Client's by-timestamp acknowledgement. Rather than return a
+    # silently-empty list or a misleading count, shimmer reports clearly that
+    # warnings are unsupported. Use the notices methods instead.
+    _WARNINGS_UNSUPPORTED = (
+        "Pebble has deprecated warnings (the warnings API has been removed and "
+        "warnings are now surfaced as notices), so shimmer does not support "
+        "{method}. Use get_notices()/get_notice() instead."
+    )
+
     def get_warnings(
         self,
-        select: WarningState | None = None,
+        select: WarningState = WarningState.PENDING,
     ) -> list[Warning]:
-        """Get warnings."""
-        cmd = ["warnings"]
-        if select:
-            cmd.extend(["--select", str(select)])
-
-        result = self._run_command(cmd)
-        output = result.stdout.strip()
-        if not output or output == "No warnings.":
-            return []
-
+        """Unsupported: warnings are deprecated in Pebble (see get_notices)."""
         raise NotImplementedError(
-            "Parsing of non-empty warnings output is not yet implemented"
+            self._WARNINGS_UNSUPPORTED.format(method="get_warnings()")
         )
 
     def ack_warnings(self, timestamp: datetime.datetime) -> int:
-        """Acknowledge warnings up to timestamp."""
-        raise NotImplementedError
+        """Unsupported: warnings are deprecated in Pebble (see get_notices)."""
+        raise NotImplementedError(
+            self._WARNINGS_UNSUPPORTED.format(method="ack_warnings()")
+        )
 
     def get_identities(self) -> dict[str, Identity]:
         """Get all identities."""
@@ -783,7 +859,7 @@ class PebbleCliClient:
 
     def replace_identities(
         self,
-        identities: dict[str, IdentityDict | Identity | None],
+        identities: Mapping[str, IdentityDict | Identity | None],
     ):
         """Replace identities."""
         identity_data = {}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,344 @@
+#! /usr/bin/env python
+
+"""Shared infrastructure for Shimmer integration tests.
+
+The parity tests in :mod:`test_parity` drive two *independent, identical*
+Pebble daemons: one through :class:`ops.pebble.Client` (the real socket client)
+and one through :class:`shimmer.PebbleCliClient` (the CLI shim). The same
+operation is applied to both and the observable results are compared, so any
+behavioural divergence between the socket and CLI paths shows up as a test
+failure.
+
+These tests require a real Pebble installation:
+
+1. Pebble binary available in PATH or at ``/snap/bin/pebble``.
+2. Permission to create/modify temporary Pebble directories.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import enum
+import pathlib
+import subprocess
+import time
+from collections.abc import Callable, Generator
+from typing import Any
+
+import ops
+import pytest
+
+from shimmer import PebbleCliClient
+
+pytestmark = pytest.mark.integration
+
+
+# The layer both daemons start with. Keeping it identical on both sides is what
+# makes the read-back comparisons meaningful.
+BASE_LAYER = """\
+summary: Test layer for integration tests
+description: A simple layer for testing Shimmer
+services:
+  test-service:
+    override: replace
+    summary: Test service
+    command: sleep 3600
+    startup: disabled
+checks:
+  test-check:
+    override: replace
+    level: alive
+    exec:
+      command: echo "healthy"
+    period: 10s
+    timeout: 3s
+"""
+
+
+# A check-free layer for tests that compare the *change list*: the BASE_LAYER's
+# health check spawns recurring `perform-check` changes at slightly different
+# wall-clock moments on each daemon, so a change-list snapshot would never match
+# byte-for-byte. With no checks, the only changes are the ones the test drives.
+CHECKLESS_LAYER = """\
+summary: Check-free layer for change-parity tests
+services:
+  test-service:
+    override: replace
+    command: sleep 3600
+    startup: disabled
+"""
+
+
+def get_pebble_binary() -> str | None:
+    """Return the path to a usable pebble binary, or None."""
+    candidates = ["pebble", "/snap/bin/pebble"]
+    for binary in candidates:
+        try:
+            # Use --client: a plain `pebble version` does a server check that
+            # blocks for ~5s when no daemon is running.
+            result = subprocess.run(
+                [binary, "version", "--client"], capture_output=True, timeout=10
+            )
+            if result.returncode == 0:
+                return binary
+        except (
+            FileNotFoundError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ):
+            continue
+    return None
+
+
+@pytest.fixture(scope="session")
+def pebble_binary() -> str:
+    """Path to the pebble binary for the session, or skip."""
+    pebble = get_pebble_binary()
+    if not pebble:
+        pytest.skip("Pebble binary not available")
+    return pebble
+
+
+def _start_daemon(
+    pebble_binary: str, root: pathlib.Path, layer: str
+) -> tuple[subprocess.Popen[bytes], str]:
+    """Start a `pebble run --hold` daemon rooted at ``root``.
+
+    Returns the process handle and the socket path it listens on.
+    """
+    pebble_dir = root / "pebble"
+    (pebble_dir / "layers").mkdir(parents=True)
+    (pebble_dir / "layers" / "001-test.yaml").write_text(layer)
+    socket_path = str(pebble_dir / ".pebble.socket")
+    # Reuse PebbleCliClient's env construction so the daemon and the CLI client
+    # agree on PEBBLE / PEBBLE_SOCKET.
+    env = PebbleCliClient(socket_path=socket_path, pebble_binary=pebble_binary)._env
+    process = subprocess.Popen(
+        [pebble_binary, "run", "--hold"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return process, socket_path
+
+
+def _wait_ready(client: Any) -> None:
+    """Poll until the daemon behind ``client`` is serving on its socket."""
+    for attempt in range(60):
+        try:
+            client.get_services()
+            return
+        except (ConnectionError, ops.pebble.ConnectionError, ops.pebble.APIError):
+            if attempt == 59:
+                raise
+            time.sleep(0.5)
+
+
+def _terminate(process: subprocess.Popen[bytes]) -> None:
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+@dataclasses.dataclass
+class Twins:
+    """A matched pair of clients, each driving its own identical daemon.
+
+    ``socket`` is the reference :class:`ops.pebble.Client`; ``cli`` is the
+    :class:`shimmer.PebbleCliClient` under test.
+    """
+
+    socket: ops.pebble.Client
+    cli: PebbleCliClient
+
+    @property
+    def both(self) -> tuple[ops.pebble.Client, PebbleCliClient]:
+        return (self.socket, self.cli)
+
+
+def _twin_daemons(
+    pebble_binary: str, tmp_path: pathlib.Path, layer: str
+) -> Generator[Twins, None, None]:
+    """Boot two identical daemons from ``layer`` and yield matched clients."""
+    processes: list[subprocess.Popen[bytes]] = []
+    try:
+        socket_proc, socket_path = _start_daemon(
+            pebble_binary, tmp_path / "socket", layer
+        )
+        processes.append(socket_proc)
+        cli_proc, cli_socket_path = _start_daemon(
+            pebble_binary, tmp_path / "cli", layer
+        )
+        processes.append(cli_proc)
+
+        socket_client = ops.pebble.Client(socket_path=socket_path)
+        cli_client = PebbleCliClient(
+            socket_path=cli_socket_path,
+            pebble_binary=pebble_binary,
+            timeout=30.0,
+        )
+
+        _wait_ready(socket_client)
+        _wait_ready(cli_client)
+
+        yield Twins(socket=socket_client, cli=cli_client)
+    finally:
+        for process in processes:
+            _terminate(process)
+
+
+@pytest.fixture
+def twins(pebble_binary: str, tmp_path: pathlib.Path) -> Generator[Twins, None, None]:
+    """Two identical Pebble daemons (with the standard service + check)."""
+    yield from _twin_daemons(pebble_binary, tmp_path, BASE_LAYER)
+
+
+@pytest.fixture
+def twins_no_checks(
+    pebble_binary: str, tmp_path: pathlib.Path
+) -> Generator[Twins, None, None]:
+    """Two identical Pebble daemons with no health checks.
+
+    Use for change-list comparisons, where recurring check changes would
+    otherwise make snapshots diverge between the two daemons.
+    """
+    yield from _twin_daemons(pebble_binary, tmp_path, CHECKLESS_LAYER)
+
+
+# --- Normalisation & comparison ---------------------------------------------
+
+# Fields whose values legitimately differ between two independent daemons (wall
+# clock timestamps, durations measured from "now"). They are dropped before
+# comparison; their presence/typing is asserted separately where it matters.
+VOLATILE_FIELDS = frozenset(
+    {
+        "current_since",
+        "first_occurred",
+        "last_occurred",
+        "last_repeated",
+        "spawn_time",
+        "ready_time",
+        "last_modified",
+        # Task log lines embed wall-clock timestamps, so they never match
+        # byte-for-byte between two independently running daemons.
+        "log",
+    }
+)
+
+
+def normalize(obj: Any, *, drop: frozenset[str] | set[str] = frozenset()) -> Any:
+    """Convert an ops.pebble result into a stable, comparable structure.
+
+    Enums become their values, datetimes collapse to a sentinel (so a missing
+    vs present timestamp is still caught), and objects become sorted dicts of
+    their attributes with volatile and caller-specified fields removed.
+    """
+    dropped = VOLATILE_FIELDS | set(drop)
+
+    def _n(o: Any) -> Any:
+        if isinstance(o, enum.Enum):
+            return o.value
+        if isinstance(o, datetime.datetime):
+            return "<datetime>"
+        if isinstance(o, datetime.timedelta):
+            return o.total_seconds()
+        if isinstance(o, (list, tuple)):
+            return [_n(x) for x in o]
+        if isinstance(o, dict):
+            return {k: _n(v) for k, v in sorted(o.items()) if k not in dropped}
+        if hasattr(o, "to_dict"):
+            return _n(o.to_dict())
+        if hasattr(o, "__dict__"):
+            return {k: _n(v) for k, v in sorted(vars(o).items()) if k not in dropped}
+        return o
+
+    return _n(obj)
+
+
+def assert_parity(
+    socket_result: Any,
+    cli_result: Any,
+    *,
+    drop: frozenset[str] | set[str] = frozenset(),
+) -> None:
+    """Assert two results are equal once volatile fields are normalised away."""
+    s = normalize(socket_result, drop=drop)
+    c = normalize(cli_result, drop=drop)
+    assert s == c, f"parity mismatch:\n  socket: {s}\n  cli:    {c}"
+
+
+def both_results(twins: Twins, op: Callable[[Any], Any]) -> tuple[Any, Any]:
+    """Run ``op`` against both clients, returning (socket_result, cli_result)."""
+    return op(twins.socket), op(twins.cli)
+
+
+def capture_exc(client: Any, op: Callable[[Any], Any]) -> BaseException | None:
+    """Run ``op(client)`` and return the exception it raised, or None."""
+    try:
+        op(client)
+    except BaseException as exc:  # noqa: BLE001 - we re-inspect the type
+        return exc
+    return None
+
+
+def assert_same_exception(
+    twins: Twins, op: Callable[[Any], Any]
+) -> tuple[BaseException, BaseException]:
+    """Assert both clients raise, with the same exception type. Returns both."""
+    socket_exc = capture_exc(twins.socket, op)
+    cli_exc = capture_exc(twins.cli, op)
+    assert socket_exc is not None, "socket client did not raise"
+    assert cli_exc is not None, "cli client did not raise"
+    assert type(socket_exc) is type(cli_exc), (
+        f"exception type mismatch: socket raised {type(socket_exc).__name__}, "
+        f"cli raised {type(cli_exc).__name__}"
+    )
+    return socket_exc, cli_exc
+
+
+def assert_same_outcome(
+    twins: Twins,
+    op: Callable[[Any], Any],
+    *,
+    drop: frozenset[str] | set[str] = frozenset(),
+) -> None:
+    """Assert ``op`` produces the same outcome on both clients.
+
+    "Same outcome" means: both return (and the values match after
+    normalisation), or both raise the same exception type. A return on one side
+    and a raise on the other is a mismatch.
+    """
+
+    def outcome(client: Any) -> tuple[str, Any]:
+        try:
+            return ("returned", op(client))
+        except BaseException as exc:  # noqa: BLE001
+            return ("raised", exc)
+
+    socket_kind, socket_val = outcome(twins.socket)
+    cli_kind, cli_val = outcome(twins.cli)
+    assert socket_kind == cli_kind, (
+        f"outcome mismatch: socket {socket_kind} {socket_val!r}, "
+        f"cli {cli_kind} {cli_val!r}"
+    )
+    if socket_kind == "returned":
+        assert_parity(socket_val, cli_val, drop=drop)
+    else:
+        assert type(socket_val) is type(cli_val), (
+            f"exception type mismatch: socket {type(socket_val).__name__}, "
+            f"cli {type(cli_val).__name__}"
+        )
+
+
+def wait_until_ready(client: Any, change_id: Any, timeout: float = 15.0) -> None:
+    """Poll ``client.get_change(change_id)`` until the change is ready."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if client.get_change(change_id).ready:
+            return
+        time.sleep(0.2)
+    raise AssertionError(f"change {change_id} not ready within {timeout}s")

--- a/tests/integration/test_parity.py
+++ b/tests/integration/test_parity.py
@@ -1,0 +1,380 @@
+#! /usr/bin/env python
+
+"""Parity tests: shimmer (CLI) must behave exactly like ops.pebble.Client.
+
+Each test applies the same operation to two identical Pebble daemons -- one
+driven by :class:`ops.pebble.Client` over its socket, one by
+:class:`shimmer.PebbleCliClient` via the CLI -- and asserts the observable
+results match. See :mod:`conftest` for the twin-daemon fixture and the
+normalisation/comparison helpers.
+
+Where a test is marked ``xfail`` it documents a real, known divergence between
+shimmer and ops.pebble.Client (not a flaky test); see the reason string.
+"""
+
+from __future__ import annotations
+
+import signal
+import time
+
+import ops
+import pytest
+
+from .conftest import (
+    Twins,
+    assert_parity,
+    assert_same_exception,
+    assert_same_outcome,
+    both_results,
+    wait_until_ready,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# A second layer used by mutation tests, identical for both daemons.
+EXTRA_LAYER = """\
+summary: Dynamic test layer
+services:
+  dynamic-service:
+    override: replace
+    command: echo "dynamic service"
+    startup: disabled
+"""
+
+
+class TestSystemParity:
+    def test_get_system_info(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_system_info())
+        assert_parity(s, c)
+
+
+class TestLayerParity:
+    def test_get_plan(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_plan())
+        assert_parity(s, c)
+
+    def test_add_layer(self, twins: Twins):
+        for client in twins.both:
+            client.add_layer("dynamic", EXTRA_LAYER)
+        s, c = both_results(twins, lambda cl: cl.get_plan())
+        assert_parity(s, c)
+        assert "dynamic-service" in c.services
+
+    def test_add_layer_combine(self, twins: Twins):
+        override = """\
+summary: override
+services:
+  test-service:
+    override: merge
+    environment:
+      ADDED: "1"
+"""
+        for client in twins.both:
+            client.add_layer("test", override, combine=True)
+        s, c = both_results(twins, lambda cl: cl.get_plan())
+        assert_parity(s, c)
+
+
+class TestServiceParity:
+    def test_get_services(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_services())
+        assert_parity(s, c)
+
+    def test_get_services_named(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_services(["test-service"]))
+        assert_parity(s, c)
+
+    def test_start_services(self, twins: Twins):
+        # The change id is non-deterministic in form but both must return a str.
+        for client in twins.both:
+            change_id = client.start_services(["test-service"])
+            assert isinstance(change_id, str) and change_id
+        s, c = both_results(twins, lambda cl: cl.get_services(["test-service"]))
+        assert_parity(s, c)
+        assert c[0].current == ops.pebble.ServiceStatus.ACTIVE
+
+    def test_stop_services(self, twins: Twins):
+        for client in twins.both:
+            client.start_services(["test-service"])
+        for client in twins.both:
+            client.stop_services(["test-service"])
+        s, c = both_results(twins, lambda cl: cl.get_services(["test-service"]))
+        assert_parity(s, c)
+        assert c[0].current == ops.pebble.ServiceStatus.INACTIVE
+
+    def test_restart_services(self, twins: Twins):
+        for client in twins.both:
+            client.start_services(["test-service"])
+        for client in twins.both:
+            client.restart_services(["test-service"])
+        s, c = both_results(twins, lambda cl: cl.get_services(["test-service"]))
+        assert_parity(s, c)
+        assert c[0].current == ops.pebble.ServiceStatus.ACTIVE
+
+    def test_start_returns_matching_change_id(self, twins_no_checks: Twins):
+        # In no-wait mode (timeout=0) shimmer can parse the real change id from
+        # the CLI, so it matches the socket client's id on lockstep daemons.
+        s = twins_no_checks.socket.start_services(["test-service"], timeout=0)
+        c = twins_no_checks.cli.start_services(["test-service"], timeout=0)
+        assert str(s) == str(c)
+
+    def test_start_returns_real_change_id_when_waiting(self, twins_no_checks: Twins):
+        # Default (waiting) mode must still return the real change id.
+        s = twins_no_checks.socket.start_services(["test-service"])
+        c = twins_no_checks.cli.start_services(["test-service"])
+        assert str(s) == str(c) != "?"
+
+    def test_autostart_no_default_services(self, twins: Twins):
+        # test-service is startup: disabled, so there is nothing to autostart;
+        # both clients must raise APIError("no default services").
+        assert_same_outcome(twins, lambda cl: cl.autostart_services(timeout=0))
+
+    def test_send_signal(self, twins: Twins):
+        for client in twins.both:
+            client.start_services(["test-service"])
+        time.sleep(0.5)
+        for client in twins.both:
+            # SIGCONT is a no-op for a running `sleep`, so the service stays up
+            # on both sides and we compare the resulting (unchanged) state.
+            client.send_signal(signal.SIGCONT, ["test-service"])
+        s, c = both_results(twins, lambda cl: cl.get_services(["test-service"]))
+        assert_parity(s, c)
+
+
+class TestCheckParity:
+    def test_get_checks(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_checks())
+        assert_parity(s, c)
+
+    def test_get_checks_named(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_checks(names=["test-check"]))
+        assert_parity(s, c)
+
+    def test_start_checks_readback(self, twins: Twins):
+        # The resulting check state must match, regardless of the return value.
+        for client in twins.both:
+            client.start_checks(["test-check"])
+        s, c = both_results(twins, lambda cl: cl.get_checks(names=["test-check"]))
+        assert_parity(s, c)
+
+    def test_stop_checks_readback(self, twins: Twins):
+        for client in twins.both:
+            client.stop_checks(["test-check"])
+        s, c = both_results(twins, lambda cl: cl.get_checks(names=["test-check"]))
+        assert_parity(s, c)
+
+    def test_start_checks_return_value(self, twins: Twins):
+        # test-check is already running, so nothing changes -> both return [].
+        s, c = both_results(twins, lambda cl: cl.start_checks(["test-check"]))
+        assert s == c
+
+
+class TestFileParity:
+    def test_push_pull_text(self, twins: Twins):
+        content = "Hello from parity test!\n"
+        for client in twins.both:
+            client.push("/tmp/parity_text.txt", content)
+        s, c = both_results(twins, lambda cl: cl.pull("/tmp/parity_text.txt").read())
+        assert s == c == content
+
+    def test_push_pull_binary(self, twins: Twins):
+        content = b"\x00\x01\x02\x03\xff\xfe\xfd"
+        for client in twins.both:
+            client.push("/tmp/parity_bin", content)
+        s, c = both_results(
+            twins, lambda cl: cl.pull("/tmp/parity_bin", encoding=None).read()
+        )
+        assert s == c == content
+
+    def test_list_files(self, twins: Twins):
+        for client in twins.both:
+            client.push("/tmp/parity_ls/a.txt", "a", make_dirs=True)
+            client.push("/tmp/parity_ls/b.txt", "b", make_dirs=True)
+        # last_modified is volatile and dropped by normalize().
+        s, c = both_results(twins, lambda cl: cl.list_files("/tmp/parity_ls"))
+        assert_parity(s, c)
+
+    def test_list_files_pattern(self, twins: Twins):
+        for client in twins.both:
+            client.push("/tmp/parity_glob/keep.log", "x", make_dirs=True)
+            client.push("/tmp/parity_glob/skip.txt", "y", make_dirs=True)
+        s, c = both_results(
+            twins, lambda cl: cl.list_files("/tmp/parity_glob", pattern="*.log")
+        )
+        assert_parity(s, c)
+
+    def test_make_dir(self, twins: Twins):
+        for client in twins.both:
+            client.make_dir("/tmp/parity_mkdir/sub", make_parents=True)
+        s, c = both_results(
+            twins, lambda cl: cl.list_files("/tmp/parity_mkdir", itself=True)
+        )
+        assert_parity(s, c)
+
+    def test_remove_path(self, twins: Twins):
+        for client in twins.both:
+            client.push("/tmp/parity_rm.txt", "bye")
+            client.remove_path("/tmp/parity_rm.txt")
+        s, c = both_results(twins, lambda cl: cl.list_files("/tmp"))
+        # Both should agree the file is gone; comparing /tmp listings is heavy,
+        # so just assert neither lists it.
+        assert "parity_rm.txt" not in {f.name for f in c}
+        assert "parity_rm.txt" not in {f.name for f in s}
+
+
+class TestExecParity:
+    def test_exec_simple(self, twins: Twins):
+        s, c = both_results(
+            twins, lambda cl: cl.exec(["echo", "hello world"]).wait_output()
+        )
+        assert s == c
+
+    def test_exec_environment(self, twins: Twins):
+        op = lambda cl: cl.exec(  # noqa: E731
+            ["sh", "-c", 'echo "$TEST_VAR"'],
+            environment={"TEST_VAR": "value"},
+        ).wait_output()
+        s, c = both_results(twins, op)
+        assert s == c
+
+    def test_exec_working_dir(self, twins: Twins):
+        s, c = both_results(
+            twins, lambda cl: cl.exec(["pwd"], working_dir="/tmp").wait_output()
+        )
+        assert s == c
+
+    def test_exec_stdin(self, twins: Twins):
+        s, c = both_results(
+            twins, lambda cl: cl.exec(["cat"], stdin="piped\n").wait_output()
+        )
+        assert s == c
+
+    def test_exec_failure(self, twins: Twins):
+        op = lambda cl: cl.exec(["false"]).wait_output()  # noqa: E731
+        socket_exc, cli_exc = assert_same_exception(twins, op)
+        assert isinstance(socket_exc, ops.pebble.ExecError)
+        assert isinstance(cli_exc, ops.pebble.ExecError)
+        assert socket_exc.exit_code == cli_exc.exit_code
+        assert socket_exc.command == cli_exc.command
+
+
+class TestChangeParity:
+    # These use the check-free fixture so the only change is the one we drive;
+    # the BASE_LAYER check would otherwise spawn recurring perform-check changes
+    # at different moments on each daemon. timeout=0 gives shimmer the real
+    # change id (see TestServiceParity).
+
+    def test_get_changes_ready(self, twins_no_checks: Twins):
+        # Equalise the filter explicitly: with the change complete, select=READY
+        # returns the single start change on both sides.
+        for client in twins_no_checks.both:
+            change_id = client.start_services(["test-service"], timeout=0)
+            wait_until_ready(client, change_id)
+        s, c = both_results(
+            twins_no_checks,
+            lambda cl: cl.get_changes(select=ops.pebble.ChangeState.READY),
+        )
+        assert_parity(s, c)
+
+    def test_get_changes_default_select(self, twins_no_checks: Twins):
+        for client in twins_no_checks.both:
+            change_id = client.start_services(["test-service"], timeout=0)
+            wait_until_ready(client, change_id)
+        # Default select=IN_PROGRESS, so a completed change yields [] on both.
+        s, c = both_results(twins_no_checks, lambda cl: cl.get_changes())
+        assert_parity(s, c)
+
+    def test_wait_change(self, twins_no_checks: Twins):
+        socket_id = twins_no_checks.socket.start_services(["test-service"], timeout=0)
+        cli_id = twins_no_checks.cli.start_services(["test-service"], timeout=0)
+        s = twins_no_checks.socket.wait_change(socket_id, timeout=10.0)
+        c = twins_no_checks.cli.wait_change(cli_id, timeout=10.0)
+        assert s.ready and c.ready
+        assert_parity(s, c)
+
+    def test_get_change_by_id(self, twins_no_checks: Twins):
+        socket_id = twins_no_checks.socket.start_services(["test-service"], timeout=0)
+        cli_id = twins_no_checks.cli.start_services(["test-service"], timeout=0)
+        wait_until_ready(twins_no_checks.socket, socket_id)
+        wait_until_ready(twins_no_checks.cli, cli_id)
+        s = twins_no_checks.socket.get_change(socket_id)
+        c = twins_no_checks.cli.get_change(cli_id)
+        assert_parity(s, c)
+
+
+class TestNoticeParity:
+    def test_notify_and_get_notices(self, twins: Twins):
+        for client in twins.both:
+            client.notify(
+                ops.pebble.NoticeType.CUSTOM,
+                "shimmer.test/parity",
+                data={"hello": "world"},
+            )
+        s, c = both_results(twins, lambda cl: cl.get_notices())
+        assert_parity(s, c)
+
+    def test_get_notice_by_id(self, twins: Twins):
+        socket_id = twins.socket.notify(
+            ops.pebble.NoticeType.CUSTOM, "shimmer.test/byid", data={"k": "v"}
+        )
+        cli_id = twins.cli.notify(
+            ops.pebble.NoticeType.CUSTOM, "shimmer.test/byid", data={"k": "v"}
+        )
+        s = twins.socket.get_notice(socket_id)
+        c = twins.cli.get_notice(cli_id)
+        assert_parity(s, c, drop={"id"})
+
+
+# Warnings have no parity tests: they are deprecated in Pebble (the API
+# endpoint is removed) and shimmer intentionally raises NotImplementedError for
+# get_warnings()/ack_warnings(). That documented behaviour is covered by a
+# unit test (tests/unit/test_client.py::...::test_warnings_unsupported).
+
+
+class TestIdentityParity:
+    # Use 'local' (user-id) identities: 'basic' auth stores a salted password
+    # hash that differs between daemons, which is not a real divergence.
+    IDENTITIES: dict[str, ops.pebble.IdentityDict] = {
+        "alice": {"access": "admin", "local": {"user-id": 1000}}
+    }
+
+    def test_get_identities_empty(self, twins: Twins):
+        s, c = both_results(twins, lambda cl: cl.get_identities())
+        assert_parity(s, c)
+
+    def test_replace_identities(self, twins: Twins):
+        for client in twins.both:
+            client.replace_identities(self.IDENTITIES)
+        s, c = both_results(twins, lambda cl: cl.get_identities())
+        assert_parity(s, c)
+        assert "alice" in c
+
+    def test_remove_identities(self, twins: Twins):
+        for client in twins.both:
+            client.replace_identities(self.IDENTITIES)
+            client.remove_identities(["alice"])
+        s, c = both_results(twins, lambda cl: cl.get_identities())
+        assert_parity(s, c)
+        assert "alice" not in c
+
+
+class TestErrorParity:
+    def test_start_unknown_service(self, twins: Twins):
+        assert_same_exception(twins, lambda cl: cl.start_services(["nonexistent"]))
+
+    def test_pull_missing_file(self, twins: Twins):
+        # Both must raise ops.pebble.PathError (not APIError).
+        socket_exc, _ = assert_same_exception(
+            twins, lambda cl: cl.pull("/nonexistent/file.txt")
+        )
+        assert isinstance(socket_exc, ops.pebble.PathError)
+
+    def test_remove_missing_file(self, twins: Twins):
+        socket_exc, _ = assert_same_exception(
+            twins, lambda cl: cl.remove_path("/nonexistent/file.txt")
+        )
+        assert isinstance(socket_exc, ops.pebble.PathError)
+
+    def test_get_change_unknown_id(self, twins: Twins):
+        assert_same_exception(twins, lambda cl: cl.get_change("999999"))

--- a/tests/integration/test_shimmer.py
+++ b/tests/integration/test_shimmer.py
@@ -1,17 +1,17 @@
 #! /usr/bin/env python
 
-"""Integration tests for Shimmer.
+"""Shimmer-only integration tests.
 
-These tests run against a real Pebble installation and require:
+Behavioural parity with ops.pebble.Client is covered by test_parity.py. This
+module holds the few integration tests that have *no* socket-client equivalent:
+failure modes specific to the CLI shim, and performance characteristics of the
+CLI path.
 
-1. Pebble binary available in PATH or specified location
-2. Proper permissions to create/modify Pebble directories
-3. No other Pebble instance running on the same socket
+These tests run against a real Pebble installation; see conftest.py.
 """
 
 from __future__ import annotations
 
-import datetime
 import pathlib
 import subprocess
 import tempfile
@@ -20,56 +20,20 @@ from collections.abc import Generator
 
 import ops
 import pytest
-import yaml
 
 from shimmer import PebbleCliClient
 
-
-def get_pebble_binary() -> str | None:
-    """Get the path to pebble binary."""
-    candidates = ["pebble", "/snap/bin/pebble"]
-    for binary in candidates:
-        try:
-            # Use --client: a plain `pebble version` does a server check that
-            # blocks for ~5s when no daemon is running.
-            result = subprocess.run(
-                [binary, "version", "--client"], capture_output=True, timeout=10
-            )
-            if result.returncode == 0:
-                return binary
-        except (
-            FileNotFoundError,
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-        ):
-            continue
-
+from .conftest import BASE_LAYER
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture(scope="session")
-def pebble_binary() -> str:
-    """Get pebble binary path for the session."""
-    pebble = get_pebble_binary()
-    if not pebble:
-        pytest.skip("Pebble binary not available")  # type: ignore
-        return ""
-    return pebble
 
 
 @pytest.fixture
 def temp_pebble_dir() -> Generator[pathlib.Path]:
     """Create a temporary Pebble directory for testing."""
     with tempfile.TemporaryDirectory(prefix="shimmer_test_") as temp_dir:
-        temp_path = pathlib.Path(temp_dir)
-        pebble_dir = temp_path / "pebble"
-        pebble_dir.mkdir()
-
-        # Create layers directory.
-        layers_dir = pebble_dir / "layers"
-        layers_dir.mkdir()
-
+        pebble_dir = pathlib.Path(temp_dir) / "pebble"
+        (pebble_dir / "layers").mkdir(parents=True)
         yield pebble_dir
 
 
@@ -77,71 +41,43 @@ def temp_pebble_dir() -> Generator[pathlib.Path]:
 def pebble_client(pebble_binary: str, temp_pebble_dir: pathlib.Path) -> PebbleCliClient:
     """Create a Shimmer client configured for testing."""
     socket_path = str(temp_pebble_dir / ".pebble.socket")
-    client = PebbleCliClient(
+    return PebbleCliClient(
         socket_path=socket_path,
         pebble_binary=pebble_binary,
         timeout=30.0,
     )
-    return client
 
 
 @pytest.fixture
 def running_pebble(
     pebble_client: PebbleCliClient, temp_pebble_dir: pathlib.Path
 ) -> Generator[PebbleCliClient]:
-    """Start Pebble daemon for testing and ensure it's stopped after."""
-    # Create a simple test layer.
-    test_layer = """
-summary: Test layer for integration tests
-description: A simple layer for testing Shimmer
-services:
-  test-service:
-    override: replace
-    summary: Test service
-    command: sleep 3600
-    startup: disabled
-checks:
-  test-check:
-    override: replace
-    level: alive
-    exec:
-      command: echo "healthy"
-    period: 10s
-    timeout: 3s
-"""
+    """Start a single Pebble daemon driven by shimmer, stopped after the test."""
+    (temp_pebble_dir / "layers" / "001-test.yaml").write_text(BASE_LAYER)
 
-    layers_dir = temp_pebble_dir / "layers"
-    test_layer_file = layers_dir / "001-test.yaml"
-    test_layer_file.write_text(test_layer)
-
-    # Start pebble daemon in background.
     pebble_process = None
     try:
         pebble_process = subprocess.Popen(
             [pebble_client.pebble_binary, "run", "--hold"],
-            env=pebble_client._env,  # type: ignore
+            env=pebble_client._env,  # type: ignore[reportPrivateUsage]
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
 
-        # Wait for pebble to start. Probe with a command that actually contacts
-        # the daemon (get_services hits the socket); get_system_info only runs
-        # `version --client`, which succeeds before the daemon is listening and
-        # would let tests race a not-yet-ready socket.
-        max_attempts = 60
-        for attempt in range(max_attempts):
+        # Probe with a command that actually contacts the daemon (get_services
+        # hits the socket); get_system_info only runs `version --client`, which
+        # succeeds before the daemon is listening.
+        for attempt in range(60):
             try:
                 pebble_client.get_services()
                 break
             except (ConnectionError, ops.pebble.APIError):
-                if attempt == max_attempts - 1:
+                if attempt == 59:
                     raise
                 time.sleep(0.5)
 
         yield pebble_client
-
     finally:
-        # Ensure pebble process is terminated:
         if pebble_process:
             pebble_process.terminate()
             try:
@@ -151,425 +87,42 @@ checks:
                 pebble_process.wait()
 
 
-class TestSystemIntegration:
-    """Test basic system integration."""
+class TestConnectionErrors:
+    """Failure modes specific to the CLI shim (no socket-client equivalent)."""
 
-    def test_system_info(self, running_pebble: PebbleCliClient):
-        """Test getting system information from real Pebble."""
-        info = running_pebble.get_system_info()
-
-        assert hasattr(info, "version")
-        assert isinstance(info.version, str)
-        assert len(info.version) > 0
-        print(f"Pebble version: {info.version}")
-
-    def test_connection_error_handling(self):
-        """Test connection error when Pebble is not running."""
-        # Don't use running_pebble fixture - test with stopped Pebble.
+    def test_connection_error_when_binary_missing(self):
+        """A non-pebble binary surfaces as a connection/API error, not a crash."""
         client = PebbleCliClient(pebble_binary="/bin/false")
         with pytest.raises((ConnectionError, ops.pebble.APIError)):
             client.get_system_info()
 
 
-class TestLayerManagement:
-    """Test layer management operations."""
-
-    def test_get_plan(self, running_pebble: PebbleCliClient):
-        """Test getting the current plan."""
-        plan = running_pebble.get_plan()
-
-        assert hasattr(plan, "services")
-        assert hasattr(plan, "checks")
-
-        # Should have our test service.
-        assert "test-service" in plan.services
-        assert "test-check" in plan.checks
-
-    def test_add_layer_and_replan(self, running_pebble: PebbleCliClient):
-        """Test adding a layer and replanning."""
-        new_layer = """
-summary: Dynamic test layer
-services:
-  dynamic-service:
-    override: replace
-    command: echo "dynamic service"
-    startup: disabled
-"""
-
-        running_pebble.add_layer("dynamic", new_layer)
-        change_id = running_pebble.replan_services(timeout=10.0)
-
-        assert isinstance(change_id, str)
-        plan = running_pebble.get_plan()
-        assert "dynamic-service" in plan.services
-
-
-class TestServiceManagement:
-    """Test service management operations."""
-
-    def test_get_services(self, running_pebble: PebbleCliClient):
-        """Test getting service status."""
-        services = running_pebble.get_services()
-
-        assert isinstance(services, list)
-        assert len(services) > 0
-
-        test_service = None
-        for service in services:
-            if service.name == "test-service":
-                test_service = service
-                break
-        assert test_service is not None
-        assert test_service.startup == ops.pebble.ServiceStartup.DISABLED
-        assert test_service.current in [
-            ops.pebble.ServiceStatus.INACTIVE,
-            ops.pebble.ServiceStatus.ACTIVE,
-        ]
-
-    @pytest.mark.skip(reason="wait_change not implemented yet")
-    def test_service_lifecycle(self, running_pebble: PebbleCliClient):
-        """Test starting and stopping services."""
-        services = running_pebble.get_services(["test-service"])
-        assert len(services) == 1
-        initial_status = services[0].current
-        if initial_status != "active":
-            change_id = running_pebble.start_services(["test-service"])
-            assert isinstance(change_id, str)
-            change = running_pebble.wait_change(change_id, timeout=10.0)
-            assert change.ready
-            services = running_pebble.get_services(["test-service"])
-            assert services[0].current == "active"
-        change_id = running_pebble.stop_services(["test-service"])
-        change = running_pebble.wait_change(change_id, timeout=10.0)
-        assert change.ready
-        services = running_pebble.get_services(["test-service"])
-        assert services[0].current == "inactive"
-
-    @staticmethod
-    def _get_pid(client: PebbleCliClient, proc_name: str) -> str:
-        # Use the file API to verify it has restarted.
-        # We'll assume that it is the only process of this name running.
-        process = client.exec(["pgrep", proc_name])
-        stdout, _ = process.wait_output()
-        pid = stdout.strip()
-        assert pid.isdigit()
-        assert isinstance(pid, str)
-        return pid
-
-    def test_restart_service(self, running_pebble: PebbleCliClient):
-        """Test restarting a service."""
-        running_pebble.start_services(["test-service"])
-        time.sleep(1)  # Let it start
-        original_pid = self._get_pid(running_pebble, "sleep")
-        running_pebble.restart_services(["test-service"], timeout=10.0)
-        time.sleep(1)  # Let it restart
-        new_pid = self._get_pid(running_pebble, "sleep")
-        assert original_pid != new_pid
-
-
-class TestCommandExecution:
-    """Test command execution functionality."""
-
-    def test_simple_exec(self, running_pebble: PebbleCliClient):
-        """Test executing a simple command."""
-        process = running_pebble.exec(["echo", "hello world"])
-        stdout, stderr = process.wait_output()
-
-        assert stdout.strip() == "hello world"
-        assert stderr is None or stderr == ""
-
-    def test_exec_with_environment(self, running_pebble: PebbleCliClient):
-        """Test command execution with environment variables."""
-        process = running_pebble.exec(
-            ["sh", "-c", 'echo "TEST_VAR=$TEST_VAR"'],
-            environment={"TEST_VAR": "test_value"},
-        )
-        stdout, _ = process.wait_output()
-
-        assert isinstance(stdout, str)
-        assert "TEST_VAR=test_value" in stdout
-
-    def test_exec_with_working_dir(self, running_pebble: PebbleCliClient):
-        """Test command execution with working directory."""
-        process = running_pebble.exec(["pwd"], working_dir="/tmp")
-        stdout, _ = process.wait_output()
-
-        assert stdout.strip() == "/tmp"
-
-    def test_exec_failure(self, running_pebble: PebbleCliClient):
-        """Test command execution failure handling."""
-        process = running_pebble.exec(["false"])
-
-        with pytest.raises(ops.pebble.ExecError) as exc_info:
-            process.wait_output()
-
-        assert isinstance(exc_info.value, ops.pebble.ExecError)
-        assert exc_info.value.exit_code != 0
-        assert exc_info.value.command == ["false"]
-
-    def test_exec_timeout(self, running_pebble: PebbleCliClient):
-        """Test command execution timeout."""
-        with pytest.raises((TimeoutError, ops.pebble.ExecError)):
-            process = running_pebble.exec(["sleep", "30"], timeout=1.0)
-            process.wait_output()
-
-    def test_exec_with_stdin(self, running_pebble: PebbleCliClient):
-        """Test command execution with stdin input."""
-        process = running_pebble.exec(["cat"], stdin="hello from stdin\n")
-        stdout, _ = process.wait_output()
-
-        assert stdout.strip() == "hello from stdin"
-
-
-class TestFileOperations:
-    """Test file operations."""
-
-    def test_file_lifecycle(self, running_pebble: PebbleCliClient):
-        """Test complete file operation lifecycle."""
-        test_content = "Hello from Shimmer integration test!\n"
-        with tempfile.TemporaryDirectory(prefix="shimmer_test_file_") as tmp:
-            test_path = pathlib.Path(tmp) / "test_file.txt"
-            running_pebble.push(str(test_path), test_content)
-            file_obj = running_pebble.pull(str(test_path))
-            read_content = file_obj.read()
-            assert read_content == test_content
-            files = running_pebble.list_files(str(test_path.parent))
-            file_names = [f.name for f in files]
-            assert pathlib.Path(test_path).name in file_names
-            running_pebble.remove_path(str(test_path))
-            files = running_pebble.list_files(str(test_path.parent))
-            file_names = [f.name for f in files]
-            assert pathlib.Path(test_path).name not in file_names
-
-    def test_directory_operations(self, running_pebble: PebbleCliClient):
-        """Test directory creation and listing."""
-        with tempfile.TemporaryDirectory(prefix="shimmer_test_dir_") as tmp:
-            test_dir = pathlib.Path(tmp) / "shimmer_test_dir"
-            running_pebble.make_dir(str(test_dir), make_parents=True)
-            running_pebble.push(f"{test_dir}/test.txt", "test content")
-            files = running_pebble.list_files(str(test_dir))
-            assert len(files) >= 1
-            file_names = [f.name for f in files]
-            assert "test.txt" in file_names
-
-    def test_binary_file_operations(self, running_pebble: PebbleCliClient):
-        """Test binary file operations."""
-        binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
-        with tempfile.TemporaryDirectory(prefix="shimmer_binary_test_") as tmp:
-            test_path = pathlib.Path(tmp) / "shimmer_binary_test"
-
-            running_pebble.push(str(test_path), binary_content)
-            file_obj = running_pebble.pull(str(test_path), encoding=None)
-            read_content = file_obj.read()
-            assert read_content == binary_content
-
-
-class TestHealthChecks:
-    """Test health check operations."""
-
-    def test_get_checks(self, running_pebble: PebbleCliClient):
-        """Test getting check status."""
-        checks = running_pebble.get_checks()
-
-        assert isinstance(checks, list)
-
-        # Should have our test check
-        test_check = None
-        for check in checks:
-            if check.name == "test-check":
-                test_check = check
-                break
-
-        assert test_check is not None
-        assert test_check.level in [
-            ops.pebble.CheckLevel.ALIVE,
-            ops.pebble.CheckLevel.READY,
-        ]
-
-    def test_check_lifecycle(self, running_pebble: PebbleCliClient):
-        """Test starting and stopping checks."""
-        # Get initial check status
-        checks = running_pebble.get_checks(names=["test-check"])
-
-        # Start the check
-        started = running_pebble.start_checks(["test-check"])
-        assert "test-check" in started
-
-        # Wait a moment for check to run
-        time.sleep(2)
-
-        # Check status should be updated
-        checks = running_pebble.get_checks(names=["test-check"])
-        assert len(checks) == 1
-
-        # Stop the check
-        stopped = running_pebble.stop_checks(["test-check"])
-        assert "test-check" in stopped
-
-
-class TestChangeManagement:
-    """Test change tracking and management."""
-
-    def test_get_changes(self, running_pebble: PebbleCliClient):
-        """Test getting change history."""
-        running_pebble.start_services(["test-service"])
-        changes = running_pebble.get_changes()
-
-        assert isinstance(changes, list)
-        assert len(changes) > 0
-
-        change = changes[0]
-        assert hasattr(change, "id")
-        assert hasattr(change, "kind")
-        assert hasattr(change, "status")
-        assert hasattr(change, "ready")
-
-    @pytest.mark.skip(reason="wait_change not implemented yet")
-    def test_wait_change(self, running_pebble: PebbleCliClient):
-        """Test waiting for change completion."""
-        change_id = running_pebble.start_services(["test-service"])
-        change = running_pebble.wait_change(change_id, timeout=10.0)
-
-        assert change.id == change_id
-        assert change.ready
-
-
-class TestNotices:
-    """Test notice operations."""
-
-    def test_custom_notice(self, running_pebble: PebbleCliClient):
-        """Test creating and retrieving custom notices."""
-        data = {"test": "integration", "timestamp": str(time.time())}
-        notice_id = running_pebble.notify(
-            type=ops.pebble.NoticeType.CUSTOM,
-            key="shimmer.test/integration",
-            data=data,
-        )
-
-        assert isinstance(notice_id, str)
-
-        notices = running_pebble.get_notices()
-
-        test_notice = None
-        for notice in notices:
-            if notice.key == "shimmer.test/integration":
-                test_notice = notice
-                break
-        assert test_notice is not None
-        assert test_notice.type == ops.pebble.NoticeType.CUSTOM
-        # Fields should be fully typed and match what the notice was created
-        # with (not fabricated, as a previous implementation did for
-        # last_occurred and last_data).
-        assert test_notice.id == notice_id
-        assert test_notice.last_data == data
-        assert isinstance(test_notice.first_occurred, datetime.datetime)
-        assert isinstance(test_notice.last_occurred, datetime.datetime)
-
-    def test_get_notice_by_id(self, running_pebble: PebbleCliClient):
-        """get_notice() looks up by ID and returns a fully-typed Notice."""
-        notice_id = running_pebble.notify(
-            type=ops.pebble.NoticeType.CUSTOM,
-            key="shimmer.test/by-id",
-            data={"hello": "world"},
-        )
-
-        notice = running_pebble.get_notice(notice_id)
-
-        assert notice.id == notice_id
-        assert notice.key == "shimmer.test/by-id"
-        assert notice.type == ops.pebble.NoticeType.CUSTOM
-        assert notice.last_data == {"hello": "world"}
-
-
-class TestErrorHandling:
-    """Test error handling in integration scenarios."""
-
-    def test_invalid_service_operations(self, running_pebble: PebbleCliClient):
-        """Test operations on non-existent services."""
-        with pytest.raises(ops.pebble.APIError):
-            running_pebble.start_services(["nonexistent-service"])
-
-    def test_invalid_file_operations(self, running_pebble: PebbleCliClient):
-        """Test operations on non-existent files."""
-        with pytest.raises(ops.pebble.APIError):
-            running_pebble.pull("/nonexistent/path/file.txt")
-
-    def test_permission_errors(self, running_pebble: PebbleCliClient):
-        """Test handling of permission errors."""
-        with pytest.raises(ops.pebble.APIError):
-            running_pebble.push("/root/restricted_file.txt", "content")
-
-
 class TestPerformance:
-    """Test performance characteristics."""
+    """Performance characteristics of the CLI path."""
 
-    def test_concurrent_operations(self, running_pebble: PebbleCliClient):
-        """Test multiple operations in sequence."""
-        start_time = time.perf_counter_ns()
+    def test_sequential_operations(self, running_pebble: PebbleCliClient):
+        """A handful of operations complete in a reasonable time."""
+        start = time.perf_counter()
 
-        # Perform multiple operations
         running_pebble.get_services()
         running_pebble.get_checks()
         running_pebble.get_changes()
         running_pebble.exec(["echo", "test"]).wait_output()
 
-        end_time = time.perf_counter_ns()
-        duration = (end_time - start_time) / 1_000_000_000.0  # Convert to seconds
-
-        assert duration < 10.0  # 10 seconds should be plenty
+        duration = time.perf_counter() - start
+        assert duration < 10.0
         print(f"4 operations completed in {duration:.2f}s")
 
     def test_large_file_operations(self, running_pebble: PebbleCliClient):
-        """Test operations with larger files."""
+        """Push/pull of a 1MB file round-trips correctly."""
         large_content = "A" * (1024 * 1024)
 
         with tempfile.TemporaryDirectory(prefix="shimmer_large_test_") as tmp:
             test_path = pathlib.Path(tmp) / "shimmer_large_test.txt"
-            start_time = time.perf_counter_ns()
+            start = time.perf_counter()
             running_pebble.push(str(test_path), large_content)
-            file_obj = running_pebble.pull(str(test_path))
-            read_content = file_obj.read()
-            end_time = time.perf_counter_ns()
-            duration = (end_time - start_time) / 1_000_000_000.0  # Convert to seconds
+            read_content = running_pebble.pull(str(test_path)).read()
+            duration = time.perf_counter() - start
 
         assert read_content == large_content
         print(f"1MB file operations completed in {duration:.2f}s")
-
-
-# Utility functions for integration tests
-def create_test_layer(
-    name: str,
-    services: dict[str, ops.pebble.ServiceDict],
-    checks: dict[str, ops.pebble.CheckDict] | None = None,
-) -> str:
-    """Create a test layer YAML string."""
-    layer: ops.pebble.LayerDict = {
-        "summary": f"Test layer {name}",
-        "description": f"Generated test layer for {name}",
-        "services": services,
-    }
-    if checks:
-        layer["checks"] = checks
-    return yaml.dump(layer)
-
-
-def wait_for_service_status(
-    client: PebbleCliClient,
-    service_name: str,
-    expected_status: str,
-    timeout: float = 10.0,
-) -> bool:
-    """Wait for a service to reach expected status."""
-    start_time = time.time()
-
-    while time.time() - start_time < timeout:
-        services = client.get_services([service_name])
-        if services and services[0].current == expected_status:
-            return True
-        time.sleep(0.5)
-
-    return False
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-m", "integration", "--tb=short"])

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 
 import ops
 import pytest
+from pytest_mock import MockerFixture
 
 from shimmer import ExecProcess, PebbleCliClient
 
@@ -156,22 +157,22 @@ class TestPebbleCliClient:
         assert plan.checks == plan_data["checks"]
         assert plan.log_targets == plan_data["log-targets"]
 
-    def test_replan_services(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test replanning services."""
-        mock_subprocess.run.return_value.stdout = "Change 42 completed"
+    def test_replan_services(
+        self, mock_subprocess: Mock, client: PebbleCliClient, mocker: MockerFixture
+    ):
+        """Replan captures the real change id (via --no-wait) and waits."""
+        mock_subprocess.run.return_value.stdout = "42"
+        wait = mocker.patch.object(client, "wait_change")
 
         change_id = client.replan_services()
 
-        assert change_id == ops.pebble.ChangeID("?")
-        mock_subprocess.run.assert_called_once_with(
-            ["mock-pebble", "replan"],
-            input=None,
-            capture_output=True,
-            text=True,
-            timeout=5.0,
-            env=client._env,  # type: ignore
-            check=True,
-        )
+        assert change_id == ops.pebble.ChangeID("42")
+        wait.assert_called_once()
+        assert mock_subprocess.run.call_args[0][0] == [
+            "mock-pebble",
+            "replan",
+            "--no-wait",
+        ]
 
     def test_replan_services_no_wait(
         self, mock_subprocess: Mock, client: PebbleCliClient
@@ -247,40 +248,58 @@ class TestPebbleCliClient:
             "json",
         ]
 
-    def test_start_services(self, mock_subprocess: Mock, client: PebbleCliClient):
+    def test_start_services(
+        self, mock_subprocess: Mock, client: PebbleCliClient, mocker: MockerFixture
+    ):
         """Test starting services."""
-        mock_subprocess.run.return_value.stdout = "Change 42 completed"
+        mock_subprocess.run.return_value.stdout = "42"
+        wait = mocker.patch.object(client, "wait_change")
 
         change_id = client.start_services(["service1", "service2"])
 
-        assert change_id == ops.pebble.ChangeID("?")
+        assert change_id == ops.pebble.ChangeID("42")
+        wait.assert_called_once()
         call_args = mock_subprocess.run.call_args[0][0]
-        assert call_args == ["mock-pebble", "start", "service1", "service2"]
+        assert call_args == [
+            "mock-pebble",
+            "start",
+            "service1",
+            "service2",
+            "--no-wait",
+        ]
 
     def test_start_services_empty_list(self, client: PebbleCliClient):
         """Test starting services with empty list raises error."""
         with pytest.raises(ValueError, match="services list cannot be empty"):
             client.start_services([])
 
-    def test_stop_services(self, mock_subprocess: Mock, client: PebbleCliClient):
+    def test_stop_services(
+        self, mock_subprocess: Mock, client: PebbleCliClient, mocker: MockerFixture
+    ):
         """Test stopping services."""
-        mock_subprocess.run.return_value.stdout = "Change 42 completed"
+        mock_subprocess.run.return_value.stdout = "42"
+        wait = mocker.patch.object(client, "wait_change")
 
         change_id = client.stop_services(["service1"])
 
-        assert change_id == ops.pebble.ChangeID("?")
+        assert change_id == ops.pebble.ChangeID("42")
+        wait.assert_called_once()
         call_args = mock_subprocess.run.call_args[0][0]
-        assert call_args == ["mock-pebble", "stop", "service1"]
+        assert call_args == ["mock-pebble", "stop", "service1", "--no-wait"]
 
-    def test_restart_services(self, mock_subprocess: Mock, client: PebbleCliClient):
+    def test_restart_services(
+        self, mock_subprocess: Mock, client: PebbleCliClient, mocker: MockerFixture
+    ):
         """Test restarting services."""
-        mock_subprocess.run.return_value.stdout = "Change 42 completed"
+        mock_subprocess.run.return_value.stdout = "42"
+        wait = mocker.patch.object(client, "wait_change")
 
         change_id = client.restart_services(["service1"])
 
-        assert change_id == ops.pebble.ChangeID("?")
+        assert change_id == ops.pebble.ChangeID("42")
+        wait.assert_called_once()
         call_args = mock_subprocess.run.call_args[0][0]
-        assert call_args == ["mock-pebble", "restart", "service1"]
+        assert call_args == ["mock-pebble", "restart", "service1", "--no-wait"]
 
     def test_send_signal_string(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test sending signal by string name."""
@@ -376,19 +395,53 @@ class TestPebbleCliClient:
         assert call_args[-2:] == ["--format", "json"]
 
     def test_start_checks(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test starting checks."""
+        """Starting checks returns those that were inactive (now started)."""
+        # get_checks (called first) reports both checks inactive.
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "checks": {
+                    "check1": {
+                        "name": "check1",
+                        "status": "inactive",
+                        "level": "alive",
+                        "threshold": 3,
+                    },
+                    "check2": {
+                        "name": "check2",
+                        "status": "inactive",
+                        "level": "alive",
+                        "threshold": 3,
+                    },
+                }
+            }
+        )
+
         started = client.start_checks(["check1", "check2"])
 
         assert started == ["check1", "check2"]
-        call_args = mock_subprocess.run.call_args[0][0]
+        call_args = mock_subprocess.run.call_args[0][0]  # last call: start-checks
         assert call_args == ["mock-pebble", "start-checks", "check1", "check2"]
 
     def test_stop_checks(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test stopping checks."""
+        """Stopping checks returns those that were running (now stopped)."""
+        # get_checks reports check1 running (status up), so stopping it changes it.
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "checks": {
+                    "check1": {
+                        "name": "check1",
+                        "status": "up",
+                        "level": "alive",
+                        "threshold": 3,
+                    }
+                }
+            }
+        )
+
         stopped = client.stop_checks(["check1"])
 
         assert stopped == ["check1"]
-        call_args = mock_subprocess.run.call_args[0][0]
+        call_args = mock_subprocess.run.call_args[0][0]  # last call: stop-checks
         assert call_args == ["mock-pebble", "stop-checks", "check1"]
 
     def test_list_files(self, mock_subprocess: Mock, client: PebbleCliClient):
@@ -622,7 +675,8 @@ class TestPebbleCliClient:
         """Test getting changes."""
         mock_subprocess.run.return_value.stdout = self._changes_json()
 
-        changes = client.get_changes()
+        # Default select is IN_PROGRESS now (matching ops); pass ALL to see both.
+        changes = client.get_changes(select=ops.pebble.ChangeState.ALL)
 
         assert len(changes) == 2
         assert changes[0].id == "1"
@@ -833,13 +887,12 @@ ID   User    Type           Key                    First                 Repeate
         with pytest.raises(ValueError, match="Only custom notices are supported"):
             client.notify(ops.pebble.NoticeType.CHANGE_UPDATE, "some-key")
 
-    def test_get_warnings_empty(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test that the no-warnings case returns an empty list."""
-        mock_subprocess.run.return_value.stdout = "No warnings.\n"
-        assert client.get_warnings() == []
-
-        mock_subprocess.run.return_value.stdout = ""
-        assert client.get_warnings() == []
+    def test_warnings_unsupported(self, client: PebbleCliClient):
+        """Warnings are deprecated in Pebble; both methods raise clearly."""
+        with pytest.raises(NotImplementedError, match="deprecated"):
+            client.get_warnings()
+        with pytest.raises(NotImplementedError, match="deprecated"):
+            client.ack_warnings(datetime.datetime.now(datetime.UTC))
 
     def test_get_identities(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting identities."""


### PR DESCRIPTION
## What

Adds **differential (parity) integration tests** that verify `shimmer.PebbleCliClient` (CLI) behaves exactly like `ops.pebble.Client` (socket), and fixes the divergences the suite uncovered.

### Parity test harness
- `tests/integration/conftest.py` — a `twins` fixture boots **two identical Pebble daemons**, one driven by `ops.pebble.Client` over its socket and one by `PebbleCliClient` via the CLI. Each command is applied to both and the results compared with a `normalize()` helper that scrubs volatile fields (timestamps, task logs). Mutations compare both the return value and the read-back state; a `twins_no_checks` variant is used for change-list snapshots.
- `tests/integration/test_parity.py` — one parity test per command across system, layers, services, signals, checks, files, exec, changes, notices, identities, plus error-type parity.
- `tests/integration/test_shimmer.py` — trimmed to the few shimmer-only cases with no socket equivalent (bad-binary error, performance).

### Compatibility fixes in `PebbleCliClient`
Writing the assertions faithfully exposed real divergences from `ops.pebble.Client`, now fixed:

- `start`/`stop`/`restart`/`replan_services` return the **real `ChangeID`** (captured via `--no-wait`, then waiting) instead of `ChangeID("?")`.
- `wait_change` is **implemented** (polling) instead of `NotImplementedError`.
- `get_changes()` defaults to `select=IN_PROGRESS`, matching ops.
- `autostart_services` raises `APIError("no default services")` when nothing is startup-enabled, matching ops.
- `start_checks`/`stop_checks` return only the checks whose state actually changed.
- `pull`/`push`/`make_dir`/`remove_path`/`list_files` raise `PathError` (with the correct `kind`) on path errors instead of `APIError`.
- `replace_identities` accepts a `Mapping`, matching ops.
- `get_warnings`/`ack_warnings` raise a clear `NotImplementedError`: warnings are deprecated in Pebble (the API endpoint is removed; use notices).

## Notes
- The integration suite needs **Pebble built from master** (the `--format json` flag the client relies on isn't in a release yet) — CI already installs it.
- The behavioural changes (e.g. `get_changes` default, `wait_change`) make `PebbleCliClient` match `ops.pebble.Client` more closely; worth a changelog/minor-version note.

## Testing
- Unit: 69 passed
- Integration (vs Pebble master): 45 passed
- `ruff` + `ty`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)