### PR TITLE
fix: gate PyPI publish on CI tests passing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
+  # Allow other workflows (e.g. publish.yaml) to gate on these checks.
+  workflow_call:
 
 permissions: {}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,8 +7,15 @@ on:
 permissions: {}
 
 jobs:
+  # Gate the release on the full lint + unit + integration suite passing for the
+  # tagged commit, so a red CI can never publish to PyPI.
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yaml
+
   build-n-publish:
     name: Build and Publish to PyPI
+    needs: ci
     runs-on: ubuntu-latest
     environment: publish-pypi
     permissions:


### PR DESCRIPTION
## Summary

Fixes #17. The publish workflow triggered on `v*` tags and went straight to **build → attest → publish** with no dependency on the lint/test jobs (which lived in a separate workflow). A tag could therefore ship a broken release to PyPI even when CI was red.

## Changes

- **`ci.yaml`**: add a `workflow_call:` trigger so the existing lint + test jobs can be reused by other workflows.
- **`publish.yaml`**: add a `ci` job that calls `./.github/workflows/ci.yaml`, and make `build-n-publish` depend on it via `needs: ci`.

The full lint + unit + integration suite now runs against the tagged commit and must pass before anything is published. No build/publish step changes, so the OIDC/attestation flow is untouched.

## Testing

- `zizmor@v1.11.0 .` — no findings (matches the `zizmor` required check).
- YAML validated; reusable-workflow call uses the now-present `workflow_call` trigger.
- CI-only change, so no `CHANGELOG.md` entry per the repo's changelog policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)