### PR TITLE
fix: test Python 3.11 (the stated minimum) in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fixes #16. `pyproject.toml` declares `requires-python = ">=3.11"`, but the CI test matrix only ran 3.12 and 3.13 — the stated minimum was never exercised. This adds `3.11` to the matrix.

## Note on the rest of #16

The other inconsistencies the issue describes have already been resolved on `main`:
- **tox `envlist`** is now `py{311,312,313}` (no longer lists 3.8–3.10).
- **Type checkers**: there's now a single one — `ty`. No `pyright`/`mypy` references remain anywhere in the repo (`.pre-commit-config.yaml` runs `ty` via `uv run`).

So the untested minimum was the last remaining gap.

## Testing

- Ran the unit suite under Python 3.11 locally (`uv run --python 3.11 --extra dev pytest -m "not integration"`): **71 passed**.
- `ruff check` / `ruff format --check`: clean.
- `zizmor@v1.11.0` on the changed workflow: no findings.
- CI-only change, so no `CHANGELOG.md` entry per the repo's changelog policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)