### PR TITLE
fix: make APIError mirror Pebble's HTTP status and message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Bug fixes and packaging:
   reimplemented in terms of `communicate()`.
 - Ship a `py.typed` marker so downstream type checkers use Shimmer's types.
 - `__version__` is derived from the installed package metadata.
+- `APIError` raised on a CLI failure now mirrors `ops.pebble.Client`: `code`
+  is the inferred HTTP status (e.g. `404` for not-found, `400` for bad
+  requests) instead of the process exit code, `status` is the matching reason
+  phrase, `message` drops the CLI's `error:` prefix so it matches the daemon's
+  message verbatim, and `body` uses Pebble's wire format
+  (`{"type": "error", "status-code": ..., "result": {"message": ...}}`).
+  Errors that can't be classified fall back to `500`. Code that branches on
+  `APIError.code` (e.g. `== 404`) now works portably across both clients.
 
 # 2025-07-25
 

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -115,18 +115,57 @@ class PebbleCliClient:
             )
             return result
         except subprocess.CalledProcessError as e:
-            raise APIError(
-                body={"message": e.stderr or str(e)},
-                code=e.returncode,
-                status="Command Failed",
-                message=e.stderr or str(e),
-            ) from e
+            raise self._api_error_from_stderr(e.stderr, e.returncode) from e
         except subprocess.TimeoutExpired as e:
             raise TimeoutError(f"Command {full_cmd} timed out") from e
         except FileNotFoundError as e:
             raise ConnectionError(
                 f"Pebble binary not found: {self.pebble_binary}"
             ) from e
+
+    # Substrings used to recover the HTTP status the *socket* client would have
+    # surfaced. The CLI only prints ``error: <message>`` and exits non-zero, so
+    # the daemon's HTTP status is lost; we infer it from the message text. These
+    # markers mirror the messages the real daemon produces (verified against
+    # ops.pebble.Client). Order matters: not-found is checked before bad-request
+    # so e.g. "cannot find ..." wins over a stray "exist".
+    _NOT_FOUND_MARKERS = ("no such file or directory", "cannot find", "not found")
+    _BAD_REQUEST_MARKERS = ("does not exist", "already exists")
+
+    @classmethod
+    def _api_error_from_stderr(cls, stderr: str | None, returncode: int) -> APIError:
+        """Build an ``APIError`` mirroring ops.pebble.Client as closely as possible.
+
+        The Pebble CLI reports daemon errors as ``error: <message>`` on stderr
+        and exits non-zero, without exposing the HTTP status the socket client
+        sees. We strip that ``error:`` prefix -- so ``message`` matches the
+        socket client's message verbatim -- and infer ``code``/``status`` from
+        the text, falling back to ``500`` when the error can't be classified.
+        ``body`` is reconstructed in Pebble's API wire format so callers that
+        inspect it (e.g. branching on ``code == 404``) see the same shape they
+        would from ops.pebble.Client.
+        """
+        message = (stderr or "").strip()
+        if message[:6].lower() == "error:":
+            message = message[6:].strip()
+        if not message:
+            message = f"pebble CLI exited with code {returncode}"
+
+        lowered = message.lower()
+        if any(m in lowered for m in cls._NOT_FOUND_MARKERS):
+            code, status = 404, "Not Found"
+        elif any(m in lowered for m in cls._BAD_REQUEST_MARKERS):
+            code, status = 400, "Bad Request"
+        else:
+            code, status = 500, "Internal Server Error"
+
+        body: dict[str, Any] = {
+            "type": "error",
+            "status-code": code,
+            "status": status,
+            "result": {"message": message},
+        }
+        return APIError(body=body, code=code, status=status, message=message)
 
     def _run_json(
         self,
@@ -680,17 +719,11 @@ class PebbleCliClient:
     def get_change(self, change_id: ChangeID) -> Change:
         # ``pebble tasks <id>`` returns the full change object (kind, tasks,
         # error and timing included), so we get the complete change directly
-        # rather than scanning the whole list.
-        try:
-            data = self._run_json(["tasks", str(change_id)])
-        except APIError as e:
-            message = f"Could not find change {change_id}"
-            raise APIError(
-                body={"message": message},
-                code=404,
-                status="Command Failed",
-                message=message,
-            ) from e
+        # rather than scanning the whole list. A missing change surfaces as
+        # ``error: cannot find change with id "<id>"``, which _run_command
+        # already turns into a 404 APIError whose message matches the socket
+        # client's, so no special-casing is needed here.
+        data = self._run_json(["tasks", str(change_id)])
         return Change.from_dict(data)
 
     def get_changes(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -82,18 +82,93 @@ class TestPebbleCliClient:
     def test_run_command_api_error(
         self, mock_subprocess: Mock, client: PebbleCliClient
     ):
-        """Test API error handling."""
-        error_response = "Error: Test error"
+        """An unclassifiable CLI error maps to a 500 with the stripped message."""
         mock_subprocess.run.side_effect = subprocess.CalledProcessError(
-            1, "cmd", stderr=error_response
+            1, "cmd", stderr="error: something went wrong"
         )
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
             client._run_command(["test"])  # type: ignore
 
-        assert isinstance(exc_info.value, ops.pebble.APIError)
-        assert exc_info.value.message == "Error: Test error"
-        assert exc_info.value.code == 1
+        err = exc_info.value
+        # The "error:" prefix is stripped so the message matches the socket
+        # client's, and the process exit code is not leaked as the HTTP status.
+        assert err.message == "something went wrong"
+        assert err.code == 500
+        assert err.status == "Internal Server Error"
+        assert err.body == {
+            "type": "error",
+            "status-code": 500,
+            "status": "Internal Server Error",
+            "result": {"message": "something went wrong"},
+        }
+
+    @pytest.mark.parametrize(
+        ("stderr", "code", "status", "message"),
+        [
+            (
+                'error: cannot find change with id "42"',
+                404,
+                "Not Found",
+                'cannot find change with id "42"',
+            ),
+            (
+                "error: stat /no/such: no such file or directory",
+                404,
+                "Not Found",
+                "stat /no/such: no such file or directory",
+            ),
+            (
+                'error: cannot start services: service "x" does not exist',
+                400,
+                "Bad Request",
+                'cannot start services: service "x" does not exist',
+            ),
+            (
+                "error: internal server explosion",
+                500,
+                "Internal Server Error",
+                "internal server explosion",
+            ),
+        ],
+    )
+    def test_run_command_api_error_status_mapping(
+        self,
+        mock_subprocess: Mock,
+        client: PebbleCliClient,
+        stderr: str,
+        code: int,
+        status: str,
+        message: str,
+    ):
+        """CLI stderr is classified into the HTTP status the socket client uses."""
+        mock_subprocess.run.side_effect = subprocess.CalledProcessError(
+            1, "cmd", stderr=stderr
+        )
+
+        with pytest.raises(ops.pebble.APIError) as exc_info:
+            client._run_command(["test"])  # type: ignore
+
+        err = exc_info.value
+        assert err.code == code
+        assert err.status == status
+        assert err.message == message
+        assert err.body["result"]["message"] == message
+        assert err.body["status-code"] == code
+
+    def test_run_command_api_error_empty_stderr(
+        self, mock_subprocess: Mock, client: PebbleCliClient
+    ):
+        """An error with no stderr still produces a usable message."""
+        mock_subprocess.run.side_effect = subprocess.CalledProcessError(
+            3, "cmd", stderr=""
+        )
+
+        with pytest.raises(ops.pebble.APIError) as exc_info:
+            client._run_command(["test"])  # type: ignore
+
+        assert "code 3" in exc_info.value.message
+        assert exc_info.value.code == 500
 
     def test_run_command_file_not_found(
         self, mock_subprocess: Mock, client: PebbleCliClient
@@ -1009,15 +1084,18 @@ class TestCompatibilityWithOpsPebble:
     ):
         """Test that errors are raised in a compatible way."""
         mock_run.side_effect = subprocess.CalledProcessError(
-            404, "cmd", stderr='{"result": {"message": "Not found"}}'
+            1, "cmd", stderr='error: cannot find change with id "1"'
         )
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
             client.get_system_info()
 
+        # Mirrors what ops.pebble.Client would raise for the same not-found
+        # error: HTTP 404 (not the process exit code) and the daemon's message.
         assert isinstance(exc_info.value, ops.pebble.APIError)
         assert exc_info.value.code == 404
-        assert "Not found" in str(exc_info.value.message)
+        assert exc_info.value.status == "Not Found"
+        assert exc_info.value.message == 'cannot find change with id "1"'
 
         mock_run.side_effect = FileNotFoundError()
 


### PR DESCRIPTION
## Summary

Fixes #14. `_run_command` built every `APIError` straight from the subprocess result:

```python
raise APIError(
    body={"message": e.stderr or str(e)},
    code=e.returncode,            # process exit code (usually 1), not HTTP status
    status="Command Failed",
    message=e.stderr or str(e),   # raw CLI stderr, not the daemon's message
)
```

Two parity problems vs `ops.pebble.Client`:
- **`code`** was the process exit code, so portable code branching on `APIError.code == 404` never matched.
- **`message`/`body`** were the raw `error: ...` stderr rather than the daemon's structured error.

## Fix

A new `_api_error_from_stderr` helper:
- strips the CLI's `error:` prefix, so `message` matches the socket client's message **verbatim**;
- infers the HTTP status from the message text — `not-found → 404 "Not Found"`, bad-request (`does not exist` / `already exists`) `→ 400 "Bad Request"`, otherwise `→ 500 "Internal Server Error"`;
- rebuilds `body` in Pebble's API wire format (`{"type": "error", "status-code": ..., "status": ..., "result": {"message": ...}}`).

`get_change` no longer re-wraps not-found errors into a bespoke `"Could not find change"` message — `_run_command` now yields a faithful 404 whose message matches the socket client's.

The marker → status mappings were derived by observing the **real** `ops.pebble.Client` against a live daemon (e.g. `start nosvc` → 400, `get_change(999)` → 404, missing file → 404).

## Testing

- **Unit**: 76 pass. Added parametrised tests for the status mapping (404/400/500), prefix stripping, empty stderr, and `body` shape; updated the two existing error tests to assert the faithful behaviour.
- **Integration**: ran the full parity suite against a `master` Pebble build (`--format json`) — **45 pass**.
- **Live parity check**: shimmer and `ops.pebble.Client` driving twin daemons now return identical `code`/`status`/`message` for the same failure (e.g. both `APIError(400, "Bad Request", 'cannot start services: service "nosvc" does not exist')`).
- `ruff check` / `ruff format --check` clean; `ty check` passes (exit 0).
- `CHANGELOG.md` updated (user-facing behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)