### PR TITLE
chore: remove unused pyright-era type: ignore comments

### DIFF
--- a/src/shimmer/_protocol.py
+++ b/src/shimmer/_protocol.py
@@ -90,7 +90,7 @@ class PebbleClientProtocol(Protocol):
     def push(
         self,
         path: str,
-        source: ops.pebble._IOSource,  # type: ignore
+        source: ops.pebble._IOSource,
         *,
         encoding: str = "utf-8",
         make_dirs: bool = False,

--- a/tests/integration/test_shimmer.py
+++ b/tests/integration/test_shimmer.py
@@ -59,7 +59,7 @@ def running_pebble(
     try:
         pebble_process = subprocess.Popen(
             [pebble_client.pebble_binary, "run", "--hold"],
-            env=pebble_client._env,  # type: ignore[reportPrivateUsage]
+            env=pebble_client._env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -49,14 +49,14 @@ class TestPebbleCliClient:
         client = PebbleCliClient(socket_path=socket_path)
 
         expected_pebble_dir = "/tmp/test"
-        assert client._env["PEBBLE"] == expected_pebble_dir  # type: ignore
-        assert client._env["PEBBLE_SOCKET"] == socket_path  # type: ignore
+        assert client._env["PEBBLE"] == expected_pebble_dir
+        assert client._env["PEBBLE_SOCKET"] == socket_path
 
     def test_run_command_success(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test successful command execution."""
         mock_subprocess.run.return_value.stdout = "success"
 
-        result = client._run_command(["test", "command"])  # type: ignore
+        result = client._run_command(["test", "command"])
 
         mock_subprocess.run.assert_called_once()
         assert result.stdout == "success"
@@ -67,7 +67,7 @@ class TestPebbleCliClient:
         """Test command execution with input data."""
         mock_subprocess.run.return_value.stdout = "success"
 
-        client._run_command(["test"], input_data="test input")  # type: ignore
+        client._run_command(["test"], input_data="test input")
 
         call_args = mock_subprocess.run.call_args
         assert call_args[1]["input"] == "test input"
@@ -77,7 +77,7 @@ class TestPebbleCliClient:
         mock_subprocess.run.side_effect = subprocess.TimeoutExpired("cmd", 5.0)
 
         with pytest.raises(ops.pebble.TimeoutError):
-            client._run_command(["test"])  # type: ignore
+            client._run_command(["test"])
 
     def test_run_command_api_error(
         self, mock_subprocess: Mock, client: PebbleCliClient
@@ -88,7 +88,7 @@ class TestPebbleCliClient:
         )
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
-            client._run_command(["test"])  # type: ignore
+            client._run_command(["test"])
 
         err = exc_info.value
         # The "error:" prefix is stripped so the message matches the socket
@@ -147,7 +147,7 @@ class TestPebbleCliClient:
         )
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
-            client._run_command(["test"])  # type: ignore
+            client._run_command(["test"])
 
         err = exc_info.value
         assert err.code == code
@@ -165,7 +165,7 @@ class TestPebbleCliClient:
         )
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
-            client._run_command(["test"])  # type: ignore
+            client._run_command(["test"])
 
         assert "code 3" in exc_info.value.message
         assert exc_info.value.code == 500
@@ -177,7 +177,7 @@ class TestPebbleCliClient:
         mock_subprocess.run.side_effect = FileNotFoundError()
 
         with pytest.raises(ops.pebble.ConnectionError):
-            client._run_command(["test"])  # type: ignore
+            client._run_command(["test"])
 
     def test_get_system_info(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting system information."""
@@ -192,7 +192,7 @@ class TestPebbleCliClient:
             capture_output=True,
             text=True,
             timeout=5.0,
-            env=client._env,  # type: ignore
+            env=client._env,
             check=True,
         )
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -41,7 +41,7 @@ class TestPebbleCliExecProcess:
         )
 
         assert exec_process.command == ["echo", "test"]
-        assert exec_process._encoding == "utf-8"  # type: ignore
+        assert exec_process._encoding == "utf-8"
         assert exec_process.stdin == mock_process.stdin
 
     def test_wait_success(self, mock_process: Mock):


### PR DESCRIPTION
## Summary

`ty` (the project's only type checker) was emitting 12 `unused-type-ignore-comment` warnings on `ty check src tests`. They came from blanket `# type: ignore` directives left over from when the repo ran **pyright** — they suppressed pyright's private-member-access reports (`client._env`, `client._run_command`, `exec_process._encoding`, `ops.pebble._IOSource`), which `ty` doesn't emit.

This removes all 12, plus the one remaining pyright-specific `# type: ignore[reportPrivateUsage]` in the integration tests (also dead now that pyright isn't run anywhere).

After this change `ty check src tests` reports **"All checks passed!"** with no warnings, and there are no `type: ignore` comments left in `src/` or `tests/`.

## Testing

- `ty check src tests` — clean, zero warnings.
- `ruff check` / `ruff format --check` — clean.
- Unit tests: 76 pass. Integration parity suite (against a `master` Pebble build): 45 pass.
- Pure comment removals — no runtime or behaviour change, so no `CHANGELOG.md` entry (lint/tooling churn per the repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)