### PR TITLE
fix: implement abort_change so the client satisfies its protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ Bug fixes and packaging:
   (`{"type": "error", "status-code": ..., "result": {"message": ...}}`).
   Errors that can't be classified fall back to `500`. Code that branches on
   `APIError.code` (e.g. `== 404`) now works portably across both clients.
+- `abort_change()` now exists on `PebbleCliClient`, so the client implements
+  the full `ops.pebble.Client` surface (and its own `PebbleClientProtocol`).
+  The Pebble CLI exposes no command to abort a change, so it raises a clear
+  `NotImplementedError` explaining the limitation instead of failing with
+  `AttributeError`.
 
 # 2025-07-25
 

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -726,6 +726,22 @@ class PebbleCliClient:
         data = self._run_json(["tasks", str(change_id)])
         return Change.from_dict(data)
 
+    def abort_change(self, change_id: ChangeID) -> Change:
+        """Unsupported: the Pebble CLI cannot abort a change.
+
+        ops.pebble.Client.abort_change posts ``{"action": "abort"}`` to the
+        changes API, but the CLI exposes no equivalent command (only ``pebble
+        changes`` and ``pebble tasks`` exist under Changes), so there is no way
+        to back this through the CLI. The method is provided so PebbleCliClient
+        still satisfies PebbleClientProtocol / ops.pebble.Client's surface, and
+        raises a clear error rather than ``AttributeError``.
+        """
+        raise NotImplementedError(
+            "The Pebble CLI does not expose a command to abort a change, so "
+            "shimmer cannot implement abort_change(). This is a limitation of "
+            "the CLI, not of Pebble itself."
+        )
+
     def get_changes(
         self,
         select: ChangeState = ChangeState.IN_PROGRESS,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -969,6 +969,11 @@ ID   User    Type           Key                    First                 Repeate
         with pytest.raises(NotImplementedError, match="deprecated"):
             client.ack_warnings(datetime.datetime.now(datetime.UTC))
 
+    def test_abort_change_unsupported(self, client: PebbleCliClient):
+        """The CLI has no abort command, so abort_change raises clearly."""
+        with pytest.raises(NotImplementedError, match="abort"):
+            client.abort_change(ops.pebble.ChangeID("1"))
+
     def test_get_identities(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting identities."""
         mock_subprocess.run.return_value.stdout = json.dumps(
@@ -1036,6 +1041,8 @@ class TestCompatibilityWithOpsPebble:
             "push",
             "exec",
             "get_changes",
+            "get_change",
+            "abort_change",
             "wait_change",
             "get_notices",
             "get_notice",
@@ -1050,6 +1057,24 @@ class TestCompatibilityWithOpsPebble:
         for method in required_methods:
             assert hasattr(client, method), f"Missing method: {method}"
             assert callable(getattr(client, method)), f"Method not callable: {method}"
+
+    def test_satisfies_pebble_client_protocol(self, client: PebbleCliClient):
+        """The client must implement every method of PebbleClientProtocol.
+
+        Derived dynamically from the protocol so a method added there (e.g.
+        abort_change) can't silently go unimplemented on PebbleCliClient.
+        """
+        from shimmer._protocol import PebbleClientProtocol
+
+        protocol_methods = {
+            name
+            for name in dir(PebbleClientProtocol)
+            if not name.startswith("_")
+            and callable(getattr(PebbleClientProtocol, name, None))
+        }
+        assert protocol_methods, "no protocol methods discovered"
+        missing = [m for m in sorted(protocol_methods) if not hasattr(client, m)]
+        assert not missing, f"client does not satisfy protocol; missing: {missing}"
 
     def test_method_signatures_compatible(self, client: PebbleCliClient):
         """Test that method signatures are compatible with ops.pebble.Client."""


### PR DESCRIPTION
## Summary

Addresses #12. `abort_change` is declared on `PebbleClientProtocol` (and exists on `ops.pebble.Client`), but `PebbleCliClient` never implemented it — so the client **did not satisfy its own protocol**, and calling `abort_change` raised `AttributeError`.

The Pebble CLI exposes **no** command to abort a change (verified with `pebble help --all` — only `changes` and `tasks` exist under Changes), so it genuinely can't be backed by the CLI. Following the established pattern for CLI-unsupported operations (`get_warnings`/`ack_warnings`), this adds the method and raises a clear `NotImplementedError` explaining the limitation — so callers get an actionable error instead of `AttributeError`, and the protocol is satisfied.

## On the rest of #12

The other items the issue lists are already resolved on `main`:
- **Real change IDs** — the lifecycle methods (`start/stop/restart/replan/autostart`) now go through `_run_change_command`, which always passes `--no-wait` to capture and return the real change ID.
- **`wait_change()`** — implemented (polls `get_change` until ready); the previously-skipped parity tests (`test_wait_change`, `test_get_change_by_id`) are present and passing.
- **`ack_warnings()`** — intentionally unsupported: warnings are deprecated in Pebble (the API endpoint was removed), documented in code and covered by a unit test.

So `abort_change` was the last genuine gap.

## Testing

- Added `test_abort_change_unsupported` (asserts the clear `NotImplementedError`).
- Added `test_satisfies_pebble_client_protocol`: a **dynamic** conformance test that derives the method set from `PebbleClientProtocol` (31 methods) and asserts the client implements all of them — so a future protocol addition can't silently go unimplemented. Confirmed it would have failed before this change (when `abort_change` was missing).
- Added `get_change`/`abort_change` to the `required_methods` list in `test_has_all_required_methods` (both were missing).
- Unit: **78 pass**. Integration parity suite (master Pebble): **45 pass**. `ruff` + `ty` clean.
- `CHANGELOG.md` updated (user-facing surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)