### PR TITLE
fix: stream pull() from disk; document ignored opener/base_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Bug fixes and packaging:
   The Pebble CLI exposes no command to abort a change, so it raises a clear
   `NotImplementedError` explaining the limitation instead of failing with
   `AttributeError`.
+- `pull()` now returns a file handle that streams from disk instead of
+  buffering the whole file into an in-memory `io.StringIO`/`io.BytesIO`. This
+  matches `ops.pebble.Client.pull` (which also returns an open file object over
+  an unlinked temp file), so large files no longer require a full extra copy in
+  memory. The return value is still a readable text/binary file object.
 
 # 2025-07-25
 

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import datetime
 import fnmatch
-import io
 import json
 import os
 import pathlib
@@ -84,6 +83,10 @@ class PebbleCliClient:
         timeout: float = 5.0,
         pebble_binary: str = "pebble",
     ):
+        # ``opener`` and ``base_url`` are accepted only for signature parity with
+        # ops.pebble.Client (so PebbleCliClient is a drop-in). They configure the
+        # socket HTTP transport, which the CLI client doesn't use, so they are
+        # intentionally accepted-and-ignored.
         self.timeout = timeout
         self.pebble_binary = pebble_binary
         self._env = os.environ.copy()
@@ -516,19 +519,38 @@ class PebbleCliClient:
         *,
         encoding: str | None = "utf-8",
     ) -> TextIO | BinaryIO:
-        """Read a file from the remote system."""
-        with tempfile.NamedTemporaryFile() as tmp_file:
-            tmp_file.close()
-            cmd = ["pull", path, tmp_file.name]
-            try:
-                self._run_command(cmd)
-            except APIError as e:
-                self._raise_path_error(e)
-            if encoding is None:
-                with open(tmp_file.name, "rb") as tmp_file:
-                    return io.BytesIO(tmp_file.read())
-            with open(tmp_file.name, encoding=encoding) as tmp_file:
-                return io.StringIO(tmp_file.read())
+        """Read a file from the remote system.
+
+        Returns a readable file object, streaming from disk rather than
+        buffering the whole file in memory. The Pebble CLI writes the fetched
+        file to a path, so we pull into a temp file, open it, then unlink it
+        immediately: on Unix the open handle stays valid until closed, so the
+        data is still readable and the temp file is reclaimed when the caller
+        closes it. This mirrors ops.pebble.Client.pull, which likewise returns
+        an open file object over an unlinked temp file (``newline=""`` serves
+        line endings as-is, matching it).
+        """
+        fd, tmp_name = tempfile.mkstemp()
+        os.close(fd)
+        # On a failed pull the CLI removes the destination it was given, so all
+        # cleanup uses missing_ok to tolerate the temp file already being gone.
+        tmp_path = pathlib.Path(tmp_name)
+        try:
+            self._run_command(["pull", path, tmp_name])
+        except APIError as e:
+            tmp_path.unlink(missing_ok=True)
+            self._raise_path_error(e)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+        handle: TextIO | BinaryIO = (
+            open(tmp_name, "rb")
+            if encoding is None
+            else open(tmp_name, encoding=encoding, newline="")
+        )
+        tmp_path.unlink(missing_ok=True)
+        return handle
 
     def push(
         self,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -6,6 +6,7 @@ import datetime
 import inspect
 import io
 import json
+import os
 import subprocess
 from unittest.mock import Mock, patch
 
@@ -633,41 +634,71 @@ class TestPebbleCliClient:
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "rm", "/path/file", "--recursive"]
 
+    def _pull_writes(self, mock_subprocess: Mock, content: bytes) -> dict:
+        """Make the mocked `pebble pull` write ``content`` to its target path.
+
+        ``pull`` runs ``pebble pull <src> <tmp>``; we write to that temp path
+        (the last CLI arg) so the returned handle reads real data. Captures the
+        temp path so the test can assert it is unlinked afterwards.
+        """
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["path"] = cmd[-1]
+            with open(cmd[-1], "wb") as fh:
+                fh.write(content)
+            return Mock(returncode=0, stdout="", stderr="")
+
+        mock_subprocess.run.side_effect = fake_run
+        return captured
+
     def test_pull_text(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test pulling file as text."""
-        with (
-            patch("tempfile.NamedTemporaryFile") as mock_temp,
-            patch("builtins.open", create=True) as mock_open,
-        ):
-            mock_file = Mock()
-            mock_file.name = "/tmp/test"
-            mock_temp.return_value.__enter__.return_value = mock_file
-            mock_file.read.return_value = "file content"
-            mock_file.write.return_value = None
-            mock_open.return_value.__enter__.return_value = mock_file
+        """pull() returns a readable text handle and cleans up the temp file."""
+        captured = self._pull_writes(mock_subprocess, b"file content")
 
-            result = client.pull("/path/file")
+        result = client.pull("/path/file")
 
-        assert isinstance(result, io.StringIO)
-        assert result.read() == "file content"
+        content = result.read()
+        assert content == "file content"
+        assert isinstance(content, str)
+        # The temp file is unlinked immediately; the handle still reads it.
+        assert not os.path.exists(captured["path"])
+        result.close()
 
     def test_pull_binary(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test pulling file as binary."""
-        with (
-            patch("tempfile.NamedTemporaryFile") as mock_temp,
-            patch("builtins.open", create=True) as mock_open,
-        ):
-            mock_file = Mock()
-            mock_file.name = "/tmp/test"
-            mock_temp.return_value.__enter__.return_value = mock_file
-            mock_file.read.return_value = b"binary file content"
-            mock_file.write.return_value = None
-            mock_open.return_value.__enter__.return_value = mock_file
+        """pull(encoding=None) returns a readable binary handle."""
+        captured = self._pull_writes(mock_subprocess, b"binary file content")
 
-            result = client.pull("/path/file", encoding=None)
+        result = client.pull("/path/file", encoding=None)
 
-        assert isinstance(result, io.BytesIO)
-        assert result.read() == b"binary file content"
+        content = result.read()
+        assert content == b"binary file content"
+        assert isinstance(content, bytes)
+        assert not os.path.exists(captured["path"])
+        result.close()
+
+    def test_pull_missing_file_raises_path_error_and_cleans_up(
+        self, mock_subprocess: Mock, client: PebbleCliClient
+    ):
+        """A failed pull raises PathError and leaves no temp file behind."""
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["path"] = cmd[-1]
+            # The real `pebble pull` removes the destination when it fails, so
+            # the cleanup path must tolerate the temp file already being gone.
+            os.unlink(cmd[-1])
+            raise subprocess.CalledProcessError(
+                1, "cmd", stderr="error: stat /path/file: no such file or directory"
+            )
+
+        mock_subprocess.run.side_effect = fake_run
+
+        with pytest.raises(ops.pebble.PathError) as exc_info:
+            client.pull("/path/file")
+
+        assert exc_info.value.kind == "not-found"
+        assert not os.path.exists(captured["path"])
 
     def test_push_string(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test pushing string content."""


### PR DESCRIPTION
## Summary

Fixes #19 (two minor cleanups).

### `pull()` no longer buffers the whole file in memory
It previously wrote to a temp file, read it **fully** into an `io.StringIO`/`io.BytesIO`, and returned that — two full copies (disk + memory), awkward for large files. It also **diverged** from `ops.pebble.Client.pull`, which returns an open file object over an *unlinked* temp file (not an in-memory buffer).

Now `pull()` matches the socket client: pull into a temp file, `open()` it, then `unlink` immediately — on Unix the handle stays valid until closed, so the data streams from disk and the temp file is reclaimed when the caller closes it. Uses `newline=""` to match `ops.pebble.Client`'s line-ending handling. The return value is still a readable text/binary file object.

### Document the ignored `__init__` params
`opener` and `base_url` are accepted only for signature parity with `ops.pebble.Client` (they configure the socket HTTP transport, which the CLI client doesn't use). Added a comment saying they're intentionally accepted-and-ignored.

## A subtlety worth calling out

A failed `pebble pull` **removes the destination file** it was given (verified against a live daemon). My first cut unlinked unconditionally in the error path, which then raised `FileNotFoundError` instead of `PathError` — caught by the integration parity suite. Fixed by making all cleanup `unlink(missing_ok=True)`, and the unit test now simulates the CLI removing the dest so this is covered without a daemon.

## Testing

- Rewrote the `pull` unit tests to drive a realistic mock (writes to the temp path) and assert the handle's content, type, **and that the temp file is unlinked**. Added a not-found test asserting `PathError` + cleanup.
- Unit: **86 pass**. Integration parity suite (master Pebble): **45 pass** — including `test_push_pull_text/binary` and `test_pull_missing_file`.
- `ruff` + `ty` clean. `CHANGELOG.md` updated (user-facing change to `pull()`'s return).

🤖 Generated with [Claude Code](https://claude.com/claude-code)