### PR TITLE
release: 1.0.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pebble-shimmer"
-version = "1.0.0a4"
+version = "1.0.0b1"
 description = "A drop-in replacement for ops.pebble.Client that uses the Pebble CLI"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

First beta release. Bumps the package version `1.0.0a4` → `1.0.0b1`.

This is the only change — the `# 2026-05-22` CHANGELOG section already documents everything shipping in beta1 (APIError HTTP-status fidelity, `abort_change`, streaming `pull()`, CI testing 3.11, gated publish, expanded test coverage, etc.).

## Release process (after merge)

Tag the squashed merge commit `v1.0.0b1` and push it, which triggers the publish workflow (now gated on the full CI suite passing for the tagged commit) to build, attest, and publish to PyPI via OIDC.

## Verification

- `uv build` produces `pebble_shimmer-1.0.0b1-{.tar.gz,-py3-none-any.whl}`.
- Version is sourced only from `pyproject.toml`; `__version__` is derived from installed package metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)