### PR TITLE
feat: pluggable command runner for remote-pebble use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Unreleased
+
+Features:
+
+- `PebbleCliClient` now accepts an optional `runner=` keyword argument on
+  construction. The `Runner` protocol (two methods: `run` and `popen`,
+  mirroring `subprocess.run` / `subprocess.Popen`) lets callers swap out how
+  the `pebble` binary is invoked — for example, by prefixing the argv with
+  `juju ssh --container=<c> <unit> --` to drive a remote Pebble. The default
+  behaviour is unchanged: when `runner` is omitted, `LocalSubprocessRunner`
+  is used, which reproduces the previous local-subprocess behaviour
+  byte-for-byte. Both `Runner` and `LocalSubprocessRunner` are exported from
+  the top-level `shimmer` package.
+
 # 2026-05-22
 
 Features:

--- a/src/shimmer/__init__.py
+++ b/src/shimmer/__init__.py
@@ -18,11 +18,14 @@ from ops.pebble import (
 from ._client import PebbleCliClient
 from ._process import ExecProcess
 from ._protocol import PebbleClientProtocol
+from ._runner import LocalSubprocessRunner, Runner
 
 __all__ = [
     "PebbleCliClient",
     "ExecProcess",
+    "LocalSubprocessRunner",
     "PebbleClientProtocol",
+    "Runner",
     # Re-exported ops.pebble exceptions.
     "Error",
     "APIError",

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -49,6 +49,7 @@ from ops.pebble import (
 )
 
 from ._process import ExecProcess
+from ._runner import LocalSubprocessRunner, Runner
 
 
 class _NoticeYamlLoader(yaml.SafeLoader):
@@ -82,6 +83,7 @@ class PebbleCliClient:
         base_url: str = "http://localhost",
         timeout: float = 5.0,
         pebble_binary: str = "pebble",
+        runner: Runner | None = None,
     ):
         # ``opener`` and ``base_url`` are accepted only for signature parity with
         # ops.pebble.Client (so PebbleCliClient is a drop-in). They configure the
@@ -89,6 +91,7 @@ class PebbleCliClient:
         # intentionally accepted-and-ignored.
         self.timeout = timeout
         self.pebble_binary = pebble_binary
+        self._runner: Runner = runner if runner is not None else LocalSubprocessRunner()
         self._env = os.environ.copy()
         if socket_path:
             # Mirror the two environment variables the Pebble CLI honours: PEBBLE
@@ -107,11 +110,9 @@ class PebbleCliClient:
         full_cmd = [self.pebble_binary] + cmd
 
         try:
-            result = subprocess.run(
+            result = self._runner.run(
                 full_cmd,
                 input=input_data,
-                capture_output=True,
-                text=True,
                 timeout=timeout or self.timeout,
                 env=self._env,
                 check=check,
@@ -715,7 +716,7 @@ class PebbleCliClient:
             process_stderr = subprocess.STDOUT
 
         try:
-            process = subprocess.Popen(
+            process = self._runner.popen(
                 full_cmd,
                 stdin=process_stdin,
                 stdout=process_stdout,

--- a/src/shimmer/_runner.py
+++ b/src/shimmer/_runner.py
@@ -1,0 +1,112 @@
+"""Runner protocol and default local-subprocess implementation.
+
+A ``Runner`` is responsible for dispatching a ``pebble …`` argv to the
+appropriate execution backend.  The default, ``LocalSubprocessRunner``,
+reproduces the behaviour that was previously inline in ``PebbleCliClient``.
+Remote runners (e.g. a ``JujuSshRunner`` that prefixes the argv with
+``juju ssh --container=<c> <unit> --``) can implement the same two-method
+protocol without touching ``PebbleCliClient`` at all.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Mapping
+from typing import IO, Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Runner(Protocol):
+    """Protocol for command dispatch in ``PebbleCliClient``.
+
+    Implementations must provide two methods that mirror ``subprocess.run``
+    and ``subprocess.Popen`` for the argument shapes that ``PebbleCliClient``
+    actually uses.
+
+    **env handling**: the client passes ``self._env`` (a copy of
+    ``os.environ`` possibly augmented with ``PEBBLE``/``PEBBLE_SOCKET``) as
+    the ``env`` argument.  ``LocalSubprocessRunner`` forwards it unchanged to
+    the subprocess, which is identical to the previous inline behaviour.
+    Remote runners may need to translate these variables into the remote
+    environment (e.g. as ``env KEY=VAL …`` prefixes on ``juju ssh``) or
+    ignore them entirely when the remote binary has its own defaults.
+    """
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        timeout: float | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[Any]:
+        """Run *argv* to completion and return the result.
+
+        Implementations should capture stdout and stderr and use text mode,
+        mirroring ``subprocess.run(..., capture_output=True, text=True)``.
+        """
+        ...
+
+    def popen(
+        self,
+        argv: list[str],
+        *,
+        stdin: int | IO[Any] | None,
+        stdout: int | IO[Any] | None,
+        stderr: int | IO[Any] | None,
+        text: bool,
+        env: Mapping[str, str] | None = None,
+    ) -> subprocess.Popen[Any]:
+        """Start *argv* as a background process and return the handle.
+
+        Mirrors ``subprocess.Popen`` for the streaming ``exec`` path.
+        """
+        ...
+
+
+class LocalSubprocessRunner:
+    """Default runner: executes commands as local subprocesses.
+
+    This is a direct extraction of the behaviour that was previously inline
+    in ``PebbleCliClient._run_command`` and ``PebbleCliClient.exec``.
+    Existing callers see no behaviour change.
+    """
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        timeout: float | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[Any]:
+        return subprocess.run(
+            argv,
+            input=input,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            check=check,
+        )
+
+    def popen(
+        self,
+        argv: list[str],
+        *,
+        stdin: int | IO[Any] | None,
+        stdout: int | IO[Any] | None,
+        stderr: int | IO[Any] | None,
+        text: bool,
+        env: Mapping[str, str] | None = None,
+    ) -> subprocess.Popen[Any]:
+        return subprocess.Popen(
+            argv,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            text=text,
+            env=env,
+        )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -24,7 +24,7 @@ class TestPebbleCliClient:
     @pytest.fixture
     def mock_subprocess(self):
         """Mock subprocess for testing."""
-        with patch("shimmer._client.subprocess") as mock_sub:
+        with patch("shimmer._runner.subprocess") as mock_sub:
             mock_result = Mock()
             mock_result.returncode = 0
             mock_result.stdout = ""
@@ -1159,6 +1159,82 @@ ID   User    Type           Key                    First                 Repeate
         assert cmd[:2] == ["mock-pebble", "update-identities"]
         assert "--replace" in cmd
         assert captured["data"] == {"identities": {"alice": None, "bob": None}}
+
+
+class TestRunnerInjection:
+    """Tests for the pluggable runner protocol."""
+
+    def test_injected_runner_receives_full_argv_and_env(self):
+        """An injected runner sees the full pebble argv (binary + subcommand) and env."""
+        from unittest.mock import MagicMock
+
+        from shimmer import LocalSubprocessRunner, Runner
+
+        captured: dict = {}
+
+        class FakeRunner:
+            def run(self, argv, *, input=None, timeout=None, env=None, check=True):
+                captured["argv"] = argv
+                captured["env"] = env
+                result = MagicMock()
+                result.stdout = "v1.2.3\n"
+                result.stderr = ""
+                result.returncode = 0
+                return result
+
+            def popen(
+                self, argv, *, stdin, stdout, stderr, text, env=None
+            ):  # pragma: no cover
+                raise NotImplementedError
+
+        client = PebbleCliClient(pebble_binary="my-pebble", runner=FakeRunner())
+        info = client.get_system_info()
+
+        assert info.version == "v1.2.3"
+        assert captured["argv"] == ["my-pebble", "version", "--client"]
+        assert captured["env"] is client._env
+
+        # Structural check: FakeRunner satisfies the Runner protocol.
+        assert isinstance(FakeRunner(), Runner)
+        # LocalSubprocessRunner also satisfies it.
+        assert isinstance(LocalSubprocessRunner(), Runner)
+
+    def test_default_runner_is_local_subprocess(self):
+        """When no runner is provided, a LocalSubprocessRunner is used."""
+        from shimmer import LocalSubprocessRunner
+
+        client = PebbleCliClient()
+        assert isinstance(client._runner, LocalSubprocessRunner)
+
+    def test_injected_runner_popen_path(self):
+        """An injected runner's popen() is called for the exec/streaming path."""
+        from unittest.mock import MagicMock
+
+        captured: dict = {}
+
+        class FakeRunner:
+            def run(
+                self, argv, *, input=None, timeout=None, env=None, check=True
+            ):  # pragma: no cover
+                raise NotImplementedError
+
+            def popen(self, argv, *, stdin, stdout, stderr, text, env=None):
+                captured["argv"] = argv
+                captured["env"] = env
+                proc = MagicMock()
+                proc.stdin = None
+                proc.stdout = MagicMock()
+                proc.stderr = MagicMock()
+                return proc
+
+        client = PebbleCliClient(pebble_binary="my-pebble", runner=FakeRunner())
+        client.exec(["echo", "hello"])
+
+        assert captured["argv"][0] == "my-pebble"
+        assert "exec" in captured["argv"]
+        assert "echo" in captured["argv"]
+        assert "hello" in captured["argv"]
+        assert captured["env"] is client._env
 
 
 class TestCompatibilityWithOpsPebble:


### PR DESCRIPTION
Closes #45.

## Summary

- Adds a `Runner` protocol (`src/shimmer/_runner.py`) with two methods — `run` and `popen` — that mirror `subprocess.run` / `subprocess.Popen`. The protocol is `@runtime_checkable` for convenient isinstance checks.
- Adds `LocalSubprocessRunner`, which is a direct extraction of the subprocess logic previously inline in `PebbleCliClient`; it is the default and preserves the current behaviour byte-for-byte.
- Threads `runner: Runner | None = None` through `PebbleCliClient.__init__`; when omitted, `LocalSubprocessRunner()` is used automatically.
- Replaces the two direct `subprocess` call sites in `_run_command` and `exec` with `self._runner.run(...)` / `self._runner.popen(...)`. All exception translation (`FileNotFoundError → ConnectionError`, `TimeoutExpired → TimeoutError`, `CalledProcessError → APIError`) is kept at the call sites in `_client.py` — the runner's responsibility is invoking argv, not interpreting Pebble errors.
- Exports `Runner` and `LocalSubprocessRunner` from the top-level `shimmer` package.

**No behaviour change for existing callers; the default runner is the current local subprocess path.**

## env handling

`PebbleCliClient` passes `self._env` (a copy of `os.environ` optionally augmented with `PEBBLE`/`PEBBLE_SOCKET`) as the `env` argument to the runner. `LocalSubprocessRunner` forwards it unchanged to the subprocess. Remote runners may need to translate these variables into the remote environment (e.g. as `env KEY=VAL …` prefixes on `juju ssh`) or ignore them entirely if the remote binary has its own defaults. This is documented in the `Runner` docstring.

## Motivating consumer

[`canonical/cascade`](https://github.com/canonical/cascade) (in design) wants to drive a workload-container Pebble via `juju ssh --container=<c> <unit> -- /charm/bin/pebble …`. A `JujuSshRunner` that prefixes argv with the `juju ssh` invocation lives in cascade, not here.

## Test plan

- [x] `tox -e lint` — ruff check + ruff format --check + ty check all pass
- [x] `tox -e unit` — all 89 unit tests pass (86 existing + 3 new)
- [x] New `TestRunnerInjection` class exercises the runner injection point:
  - `test_injected_runner_receives_full_argv_and_env` — fake runner captures argv and env through the `_run_command` / `get_system_info()` path; asserts `pebble_binary` is argv[0] and env is forwarded correctly; checks `isinstance` against the `Runner` protocol.
  - `test_default_runner_is_local_subprocess` — asserts that `PebbleCliClient()` (no runner arg) stores a `LocalSubprocessRunner`.
  - `test_injected_runner_popen_path` — fake runner captures argv through the `exec` / `popen` path; asserts the binary and subcommand are present.

https://claude.ai/code/session_015w5VfLpT45sVHjH8pqG3RS

---
_Generated by [Claude Code](https://claude.ai/code/session_015w5VfLpT45sVHjH8pqG3RS)_