### PR TITLE
feat: use --format json for notices, fix types filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 2026-05-28
+
+Features:
+
+`get_notices()` and `get_notice()` now use Pebble's structured `--format json`
+output instead of scraping the human-readable table and parsing per-notice
+YAML. `get_notices()` reads every matching notice in a single call (it no
+longer makes a follow-up call per notice).
+
+Bug fixes and packaging:
+
+- `get_notices(types=...)` now filters correctly. It previously passed the
+  type as a positional argument, which newer Pebble rejects with "too many
+  arguments"; types are now passed via the `--type` flag.
+
 # 2026-05-22
 
 Features:

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -51,23 +51,6 @@ from ops.pebble import (
 from ._process import ExecProcess
 
 
-class _NoticeYamlLoader(yaml.SafeLoader):
-    """SafeLoader that leaves RFC3339 timestamps as strings.
-
-    ``pebble notice <id>`` emits YAML whose keys match the Pebble API wire
-    format, so the parsed mapping can be handed straight to
-    ``ops.pebble.Notice.from_dict``. PyYAML's default implicit resolver,
-    however, turns timestamp scalars into ``datetime`` objects, whereas
-    ``from_dict`` expects the raw RFC3339 strings — so we drop that resolver.
-    """
-
-
-_NoticeYamlLoader.yaml_implicit_resolvers = {
-    ch: [(tag, rx) for tag, rx in resolvers if tag != "tag:yaml.org,2002:timestamp"]
-    for ch, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
-}
-
-
 class PebbleCliClient:
     """A drop-in replacement for ops.pebble.Client that uses CLI commands.
 
@@ -828,44 +811,21 @@ class PebbleCliClient:
         if user_id is not None:
             cmd.extend(["--uid", str(user_id)])
         for t in types or []:
-            if isinstance(t, NoticeType):
-                cmd.append(str(t))
-            else:
-                cmd.append(t)
+            cmd.extend(["--type", t.value if isinstance(t, NoticeType) else t])
         for k in keys or []:
             cmd.extend(["--key", k])
 
-        result = self._run_command(cmd)
-        # The ``notices`` table only carries a subset of a notice's fields (no
-        # last-occurred, last-data, or expire-after) and renders timestamps in a
-        # lossy human form, so we use it just to discover the matching IDs and
-        # then fetch each notice in full via ``get_notice`` (which parses the
-        # complete YAML representation). The first whitespace-delimited column is
-        # the numeric ID; the remaining columns may contain spaces.
-        # Output looks like:
-        # ID   User    Type           Key                    First               Repeated            Occurrences
-        # 2    public  change-update  2                      today at 06:49 UTC  today at 06:49 UTC  3
-        lines = result.stdout.strip().splitlines()
-        # When there are no matches Pebble prints "No matching notices."; only a
-        # populated result starts with the "ID ..." header row.
-        if not lines or not lines[0].startswith("ID"):
-            return []
-        ids = [line.split(maxsplit=1)[0] for line in lines[1:] if line.strip()]
-        return [self.get_notice(notice_id) for notice_id in ids]
+        # ``--format json`` emits one object per notice with the full set of
+        # fields in the Pebble API wire format, so each entry can be handed
+        # straight to Notice.from_dict (no per-ID detail fetch needed).
+        data = self._run_json(cmd)
+        return [Notice.from_dict(notice) for notice in data["notices"]]
 
     def get_notice(self, id: str) -> Notice:
         """Get a specific notice by ID."""
-        result = self._run_command(["notice", id])
-        # ``pebble notice <id>`` emits a YAML document whose keys match the
-        # Pebble API wire format, so it can be handed to Notice.from_dict.
-        # Output looks like:
-        #   id: "12"
-        #   user-id: 1000
-        #   type: custom
-        #   key: example.com/foo
-        #   first-occurred: 2026-05-22T11:31:08.571903021Z
-        #   ...
-        data = yaml.load(result.stdout, Loader=_NoticeYamlLoader)
+        # ``pebble notice <id> --format json`` emits the notice in the Pebble
+        # API wire format, so it can be handed straight to Notice.from_dict.
+        data = self._run_json(["notice", id])
         return Notice.from_dict(data)
 
     def notify(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -923,62 +923,56 @@ class TestPebbleCliClient:
         assert mock_sleep.call_count == 2
 
     @staticmethod
-    def _notice_yaml(
+    def _notice_dict(
         id: str,
         *,
-        user_id: str = "1000",
+        user_id: int | None = 1000,
         type: str = "custom",
         key: str = "example.com/foo",
         occurrences: int = 1,
         with_data: bool = True,
-    ) -> str:
-        """Build a YAML document matching ``pebble notice <id>`` output."""
-        doc = (
-            f'id: "{id}"\n'
-            f"user-id: {user_id}\n"
-            f"type: {type}\n"
-            f'key: "{key}"\n'
-            "first-occurred: 2025-07-16T03:08:13.5Z\n"
-            "last-occurred: 2025-07-16T04:09:14.5Z\n"
-            "last-repeated: 2025-07-16T03:08:13.5Z\n"
-            f"occurrences: {occurrences}\n"
-            "expire-after: 168h0m0s\n"
-        )
+    ) -> dict[str, object]:
+        """Build a notice mapping matching ``--format json`` output."""
+        notice: dict[str, object] = {
+            "id": id,
+            "user-id": user_id,
+            "type": type,
+            "key": key,
+            "first-occurred": "2025-07-16T03:08:13.5Z",
+            "last-occurred": "2025-07-16T04:09:14.5Z",
+            "last-repeated": "2025-07-16T03:08:13.5Z",
+            "occurrences": occurrences,
+            "expire-after": "168h0m0s",
+        }
         if with_data:
-            doc += 'last-data:\n    a: "1"\n    b: "2"\n'
-        return doc
+            notice["last-data"] = {"a": "1", "b": "2"}
+        return notice
 
     def test_get_notices(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """get_notices() parses the table for IDs then fetches each in full."""
-        table = """
-ID   User    Type           Key                    First                 Repeated              Occurrences
-89   public  change-update  87                     2025-07-16T03:08:13Z  2025-07-16T03:08:13Z  3
-42   1000    custom         demo.example.com/test  2025-07-12T07:08:09Z  2025-07-16T03:08:13Z  10
-""".strip()
-        mock_subprocess.run.side_effect = [
-            Mock(returncode=0, stdout=table, stderr=""),
-            Mock(
-                returncode=0,
-                stdout=self._notice_yaml(
-                    "89",
-                    user_id="null",  # public notices render user-id as null
-                    type="change-update",
-                    key="87",
-                    occurrences=3,
-                ),
-                stderr="",
-            ),
-            Mock(
-                returncode=0,
-                stdout=self._notice_yaml(
-                    "42", key="demo.example.com/test", occurrences=10
-                ),
-                stderr="",
-            ),
-        ]
+        """get_notices() parses the full JSON list in a single call."""
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "notices": [
+                    self._notice_dict(
+                        "89",
+                        user_id=None,  # public notices render user-id as null
+                        type="change-update",
+                        key="87",
+                        occurrences=3,
+                    ),
+                    self._notice_dict(
+                        "42", key="demo.example.com/test", occurrences=10
+                    ),
+                ]
+            }
+        )
 
         notices = client.get_notices()
 
+        # A single JSON call returns full notices — no per-ID detail fetch.
+        assert mock_subprocess.run.call_count == 1
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "notices", "--format", "json"]
         assert len(notices) == 2
         assert notices[0].id == "89"
         assert notices[0].type == ops.pebble.NoticeType.CHANGE_UPDATE
@@ -990,24 +984,35 @@ ID   User    Type           Key                    First                 Repeate
         assert notices[1].key == "demo.example.com/test"
         assert notices[1].user_id == 1000
         assert notices[1].occurrences == 10
-        # The detail fetch supplies what the table cannot.
         assert notices[1].last_data == {"a": "1", "b": "2"}
 
+    def test_get_notices_filters(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """Type and key filters are passed as --type/--key flags, not positionally."""
+        mock_subprocess.run.return_value.stdout = '{"notices":[]}'
+
+        client.get_notices(
+            types=[ops.pebble.NoticeType.CUSTOM], keys=["example.com/foo"]
+        )
+
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args[call_args.index("--type") + 1] == "custom"
+        assert call_args[call_args.index("--key") + 1] == "example.com/foo"
+
     def test_get_notices_empty(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """No matching notices returns an empty list without per-ID fetches."""
-        mock_subprocess.run.return_value.stdout = "No matching notices."
+        """No matching notices returns an empty list."""
+        mock_subprocess.run.return_value.stdout = '{"notices":[]}'
 
         assert client.get_notices() == []
         assert mock_subprocess.run.call_count == 1
 
     def test_get_notice(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """get_notice() parses the full YAML document into a typed Notice."""
-        mock_subprocess.run.return_value.stdout = self._notice_yaml("12")
+        """get_notice() parses the full JSON document into a typed Notice."""
+        mock_subprocess.run.return_value.stdout = json.dumps(self._notice_dict("12"))
 
         notice = client.get_notice("12")
 
         call_args = mock_subprocess.run.call_args[0][0]
-        assert call_args == ["mock-pebble", "notice", "12"]
+        assert call_args == ["mock-pebble", "notice", "12", "--format", "json"]
         assert notice.id == "12"
         assert notice.user_id == 1000
         assert notice.type == ops.pebble.NoticeType.CUSTOM


### PR DESCRIPTION
## Summary

- `get_notices()` now reads every matching notice in a single `notices --format json` call, instead of scraping the human-readable table for IDs and then making a follow-up `get_notice()` call per notice.
- `get_notice()` parses `notice <id> --format json` instead of YAML, dropping the custom timestamp-preserving `_NoticeYamlLoader`.
- **Bug fix:** `get_notices(types=...)` now passes the type via the `--type` flag instead of as a positional argument. Newer Pebble (v1.31.0) rejects the positional form with "too many arguments". The parity tests missed this because they only call `get_notices()` with no filters.

This extends the `--format json` migration already done for the other read commands (services, checks, ls, changes, change, identities) to notices.

## Test plan

- [x] `tox -e lint` (ruff + ty) — clean
- [x] `tox -e unit` — 87 passed (added `test_get_notices_filters` covering `--type`/`--key`)
- [x] `tox -e integration` — 45 passed, run against released Pebble **v1.31.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)