### PR TITLE
release: 1.0.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2026-05-28
 
 Features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pebble-shimmer"
-version = "1.0.0b1"
+version = "1.0.0b2"
 description = "A drop-in replacement for ops.pebble.Client that uses the Pebble CLI"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the version from 1.0.0b1 to 1.0.0b2 and dates the CHANGELOG section (2026-05-28). Ships the pluggable command runner (#46) and the structured --format json notices work + types filter fix (#47).