### PR TITLE
build: fix publish warnings, render demo on PyPI, support Python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,8 @@ jobs:
           persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
@@ -45,7 +47,7 @@ jobs:
         with:
           subject-path: 'dist/*'
       - name: Attest SBOM
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v1
         with:
           subject-path: 'dist/*'
           sbom-path: 'sbom.cdx.json'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bug fixes and packaging:
+
+- Python 3.14 is now officially supported and tested.
+
 # 2026-05-28
 
 Features:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A 100% compatible, drop-in replacement for `ops.pebble.Client` that drives
 the unix socket — for environments where the socket isn't reachable (such as a
 Rock or a Juju container).
 
-![Shimmer parity demo](demo.gif)
+![Shimmer parity demo](https://raw.githubusercontent.com/tonyandrewmeyer/shimmer/main/demo.gif)
 
 <sub>The same deploy-and-verify routine run over `ops.pebble.Client` (unix
 socket, left) and `shimmer.PebbleCliClient` (CLI, right) — identical results.</sub>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration",
 ]


### PR DESCRIPTION
- Replace deprecated actions/attest-sbom with actions/attest
- Pin python-version on setup-python in the publish job
- Use an absolute raw GitHub URL for the demo GIF so it renders on PyPI
- Add Python 3.14 to the CI matrix and package classifiers