### PR TITLE
build: migrate dev extra to a PEP 735 dependency group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,27 +17,27 @@ repos:
       - id: detect-private-key
 
   # Local hooks run the tools through `uv run`, so the versions come from
-  # pyproject.toml's `dev` extra rather than from pinned `rev:`s here. This
+  # pyproject.toml's `dev` group rather than from pinned `rev:`s here. This
   # keeps pre-commit, tox and CI on exactly the same tool versions.
   - repo: local
     hooks:
       - id: ruff-check
         name: ruff check
-        entry: uv run --extra dev -- ruff check --fix --exit-non-zero-on-fix
+        entry: uv run --group dev -- ruff check --fix --exit-non-zero-on-fix
         language: system
         types: [python]
         require_serial: true
 
       - id: ruff-format
         name: ruff format
-        entry: uv run --extra dev -- ruff format
+        entry: uv run --group dev -- ruff format
         language: system
         types: [python]
         require_serial: true
 
       - id: ty
         name: ty
-        entry: uv run --extra dev -- ty check src tests
+        entry: uv run --group dev -- ty check src tests
         language: system
         types: [python]
         pass_filenames: false
@@ -52,7 +52,7 @@ repos:
 
       - id: pytest-unit
         name: pytest unit tests
-        entry: uv run --extra dev -- pytest -m "not integration" --maxfail=1 -q
+        entry: uv run --group dev -- pytest -m "not integration" --maxfail=1 -q
         language: system
         types: [python]
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ If you land a fix and the changelog wasn't touched, that's a miss — add it.
 
 ## Development workflow
 
-- Use **`uv`**. `uv sync --extra dev` for a dev environment.
+- Use **`uv`**. `uv sync` for a dev environment (the `dev` dependency group is
+  installed automatically).
 - **`ty`** is the type checker (not pyright/mypy). **`ruff`** does lint +
-  format. Both are pinned in the `dev` extra and run through `tox`/`uv run`, so
+  format. Both are pinned in the `dev` group and run through `tox`/`uv run`, so
   every environment uses identical versions.
 - Common commands:
   - `tox -e lint` — ruff check + ruff format --check + ty check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{311,312,313}
     lint
     unit
-minversion = 4.0.0
+minversion = 4.22
 isolated_build = true
 
 [testenv]
@@ -18,15 +18,15 @@ commands =
 
 [testenv:format]
 description = Format code with ruff
-# Use the pinned ruff/ty from the `dev` extra so format, lint, pre-commit and
+# Use the pinned ruff/ty from the `dev` group so format, lint, pre-commit and
 # CI all run identical tool versions (no unpinned drift).
-extras = dev
+dependency_groups = dev
 commands =
     ruff format src tests
 
 [testenv:lint]
 description = Run linting with ruff and ty
-extras = dev
+dependency_groups = dev
 commands =
     ruff check src tests
     ruff format --check src tests

--- a/uv.lock
+++ b/uv.lock
@@ -193,14 +193,14 @@ wheels = [
 
 [[package]]
 name = "pebble-shimmer"
-version = "1.0.0b1"
+version = "1.0.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "ops" },
     { name = "pyyaml" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
@@ -214,16 +214,19 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ops", specifier = ">=2.0.0,<4" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.14" },
-    { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=3.0.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-mock", specifier = ">=3.10.0" },
+    { name = "ruff", specifier = "==0.15.14" },
+    { name = "tox", specifier = ">=4.0.0" },
+    { name = "ty", specifier = "==0.0.38" },
+]
 
 [[package]]
 name = "platformdirs"


### PR DESCRIPTION
## Summary

- Moves the `dev` tooling dependencies from `[project.optional-dependencies]` (PEP 508 extras) to `[dependency-groups]` (PEP 735), the modern standard for non-published dev dependencies.
- Updates all tooling that consumed the old extra to use the new group reference.
- No CHANGELOG entry needed — this is a tooling-only change per CLAUDE.md conventions.

## Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | Replaced `[project.optional-dependencies] dev = [...]` with `[dependency-groups] dev = [...]` using identical pins. |
| `tox.ini` | Replaced `extras = dev` with `dependency_groups = dev` in `[testenv:lint]` and `[testenv:format]`; bumped `minversion` to `4.22` (first tox version with native PEP 735 support). |
| `CLAUDE.md` | Updated `uv sync --extra dev` to `uv sync` — uv installs the default `dev` dependency group automatically without an explicit flag. Updated surrounding wording ("in the `dev` group" instead of "in the `dev` extra"). |
| `.pre-commit-config.yaml` | Changed `uv run --extra dev` to `uv run --group dev` in all local hook entries so pre-commit picks up tools from the dependency group. |
| `uv.lock` | Regenerated to reflect the structural change in `pyproject.toml`. |

## publish.yaml — no change needed

`publish.yaml` runs `uv sync --frozen --no-dev` to install only the runtime dependencies for SBOM generation. uv's `--no-dev` flag excludes dependency groups (including the default `dev` group) by default, so this invocation continues to work correctly without modification.

## Validation

- `uv sync --group dev` — resolves cleanly
- `uv run tox -e lint` — ruff check, ruff format --check, ty check all pass
- `uv run tox -e unit` — 90 tests pass, 0 failures

https://claude.ai/code/session_01WnEzJ6DeVXzgTEeNRUvZx2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnEzJ6DeVXzgTEeNRUvZx2)_