### PR TITLE
fix: support push/pull with remote Runner implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
 
+Features:
+
+- `push` and `pull` now work correctly with remote `Runner` implementations
+  (e.g. `JujuSshRunner`).  Runners that implement the new `FileTransferRunner`
+  protocol — three methods: `upload_temp`, `download_temp`, and `cleanup_temp`
+  — delegate temporary-file staging to the runner rather than assuming a shared
+  filesystem.  `LocalSubprocessRunner` implements `FileTransferRunner`, so
+  existing local-subprocess usage is unchanged.  `FileTransferRunner` is
+  exported from the top-level `shimmer` package.
+
 Bug fixes and packaging:
 
 - Python 3.14 is now officially supported and tested.
@@ -100,4 +110,3 @@ Allow Python 3.11.
 # 2025-07-12
 
 Initial alpha version.
-

--- a/src/shimmer/__init__.py
+++ b/src/shimmer/__init__.py
@@ -18,11 +18,12 @@ from ops.pebble import (
 from ._client import PebbleCliClient
 from ._process import ExecProcess
 from ._protocol import PebbleClientProtocol
-from ._runner import LocalSubprocessRunner, Runner
+from ._runner import FileTransferRunner, LocalSubprocessRunner, Runner
 
 __all__ = [
     "PebbleCliClient",
     "ExecProcess",
+    "FileTransferRunner",
     "LocalSubprocessRunner",
     "PebbleClientProtocol",
     "Runner",

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import datetime
 import fnmatch
+import io
 import json
 import os
 import pathlib
@@ -17,7 +18,7 @@ import subprocess
 import tempfile
 import time
 from collections.abc import Iterable, Mapping
-from typing import Any, BinaryIO, NoReturn, TextIO, overload
+from typing import Any, BinaryIO, NoReturn, TextIO, cast, overload
 
 import yaml
 
@@ -49,7 +50,7 @@ from ops.pebble import (
 )
 
 from ._process import ExecProcess
-from ._runner import LocalSubprocessRunner, Runner
+from ._runner import FileTransferRunner, LocalSubprocessRunner, Runner
 
 
 class PebbleCliClient:
@@ -503,16 +504,48 @@ class PebbleCliClient:
         *,
         encoding: str | None = "utf-8",
     ) -> TextIO | BinaryIO:
-        """Read a file from the remote system.
+        """Read a file from the remote system."""
+        if hasattr(self._runner, "upload_temp") and hasattr(
+            self._runner, "download_temp"
+        ):
+            return self._pull_via_runner(
+                cast(FileTransferRunner, self._runner), path, encoding=encoding
+            )
+        return self._pull_local(path, encoding=encoding)
 
-        Returns a readable file object, streaming from disk rather than
-        buffering the whole file in memory. The Pebble CLI writes the fetched
-        file to a path, so we pull into a temp file, open it, then unlink it
-        immediately: on Unix the open handle stays valid until closed, so the
-        data is still readable and the temp file is reclaimed when the caller
-        closes it. This mirrors ops.pebble.Client.pull, which likewise returns
-        an open file object over an unlinked temp file (``newline=""`` serves
-        line endings as-is, matching it).
+    def _pull_via_runner(
+        self,
+        runner: FileTransferRunner,
+        path: str,
+        *,
+        encoding: str | None,
+    ) -> TextIO | BinaryIO:
+        """Pull using the runner's file-transfer methods (remote runner path)."""
+        tmp_path = runner.upload_temp(b"")
+        try:
+            self._run_command(["pull", path, tmp_path])
+            raw = runner.download_temp(tmp_path)
+        except APIError as e:
+            self._raise_path_error(e)
+        finally:
+            runner.cleanup_temp(tmp_path)
+        if encoding is None:
+            return io.BytesIO(raw)
+        return io.StringIO(raw.decode(encoding))
+
+    def _pull_local(
+        self,
+        path: str,
+        *,
+        encoding: str | None,
+    ) -> TextIO | BinaryIO:
+        """Pull via a local temp file (default local-subprocess path).
+
+        The Pebble CLI writes the fetched file to a path, so we pull into a
+        temp file, open it, then unlink it immediately: on Unix the open handle
+        stays valid until closed, so the data is still readable and the temp
+        file is reclaimed when the caller closes it.  This mirrors
+        ops.pebble.Client.pull (``newline=""`` serves line endings as-is).
         """
         fd, tmp_name = tempfile.mkstemp()
         os.close(fd)
@@ -571,14 +604,26 @@ class PebbleCliClient:
         elif group_id is not None:
             cmd.extend(["--gid", str(group_id)])
 
-        with tempfile.NamedTemporaryFile() as tmp_file:
-            tmp_file.write(content)
-            tmp_file.flush()
-            cmd.insert(1, tmp_file.name)
+        if hasattr(self._runner, "upload_temp"):
+            runner = cast(FileTransferRunner, self._runner)
+            tmp_path = runner.upload_temp(content)
             try:
-                self._run_command(cmd)
-            except APIError as e:
-                self._raise_path_error(e)
+                cmd.insert(1, tmp_path)
+                try:
+                    self._run_command(cmd)
+                except APIError as e:
+                    self._raise_path_error(e)
+            finally:
+                runner.cleanup_temp(tmp_path)
+        else:
+            with tempfile.NamedTemporaryFile() as tmp_file:
+                tmp_file.write(content)
+                tmp_file.flush()
+                cmd.insert(1, tmp_file.name)
+                try:
+                    self._run_command(cmd)
+                except APIError as e:
+                    self._raise_path_error(e)
 
     # Exec I/O is str if encoding is provided (the default)
     @overload

--- a/src/shimmer/_runner.py
+++ b/src/shimmer/_runner.py
@@ -10,7 +10,10 @@ protocol without touching ``PebbleCliClient`` at all.
 
 from __future__ import annotations
 
+import os
+import pathlib
 import subprocess
+import tempfile
 from collections.abc import Mapping
 from typing import IO, Any, Protocol, runtime_checkable
 
@@ -65,6 +68,40 @@ class Runner(Protocol):
         ...
 
 
+@runtime_checkable
+class FileTransferRunner(Runner, Protocol):
+    """Optional extension of ``Runner`` for staging files to pebble's filesystem.
+
+    Implement this on remote runners (e.g. ``JujuSshRunner``) so that
+    ``PebbleCliClient.push`` and ``pull`` can stage content on the remote host
+    rather than a local temp file that the remote pebble process cannot access.
+
+    ``LocalSubprocessRunner`` implements this protocol — local and remote
+    filesystems are the same, so the default behaviour is preserved.
+    """
+
+    def upload_temp(self, content: bytes) -> str:
+        """Write *content* to a temp file accessible to pebble.
+
+        Returns the absolute path that pebble can use as a source (push) or
+        destination (pull).  Call ``cleanup_temp`` when the temp file is no
+        longer needed.
+        """
+        ...
+
+    def download_temp(self, path: str) -> bytes:
+        """Return the bytes stored at *path* on pebble's filesystem."""
+        ...
+
+    def cleanup_temp(self, path: str) -> None:
+        """Remove the temp file at *path* on pebble's filesystem.
+
+        Called after ``upload_temp`` or ``download_temp`` to release the
+        staging file.
+        """
+        ...
+
+
 class LocalSubprocessRunner:
     """Default runner: executes commands as local subprocesses.
 
@@ -110,3 +147,20 @@ class LocalSubprocessRunner:
             text=text,
             env=env,
         )
+
+    def upload_temp(self, content: bytes) -> str:
+        fd, path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(content)
+        except BaseException:
+            pathlib.Path(path).unlink(missing_ok=True)
+            raise
+        return path
+
+    def download_temp(self, path: str) -> bytes:
+        with open(path, "rb") as fh:
+            return fh.read()
+
+    def cleanup_temp(self, path: str) -> None:
+        pathlib.Path(path).unlink(missing_ok=True)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -701,17 +701,100 @@ class TestPebbleCliClient:
         assert not os.path.exists(captured["path"])
 
     def test_push_string(self, mock_subprocess: Mock, client: PebbleCliClient):
-        """Test pushing string content."""
-        with patch("tempfile.NamedTemporaryFile") as mock_temp:
-            mock_file = Mock()
-            mock_file.name = "/tmp/test"
-            mock_temp.return_value.__enter__.return_value = mock_file
+        """push() with a string encodes to bytes and passes a temp path to pebble."""
+        client.push("/path/file", "content", make_dirs=True)
 
-            client.push("/path/file", "content", make_dirs=True)
-
-        mock_file.write.assert_called_once()
         call_args = mock_subprocess.run.call_args[0][0]
-        assert call_args == ["mock-pebble", "push", "/tmp/test", "/path/file", "-p"]
+        # argv shape: [binary, "push", <tmp>, <dest>, flags...]
+        assert call_args[0] == "mock-pebble"
+        assert call_args[1] == "push"
+        assert call_args[3] == "/path/file"
+        assert call_args[4] == "-p"
+
+    # --- FileTransferRunner (remote runner) tests ---
+
+    @pytest.fixture
+    def transfer_runner(self):
+        """A mock FileTransferRunner for testing remote push/pull."""
+        runner = Mock()
+        runner.upload_temp = Mock(return_value="/remote/tmp/staged")
+        runner.download_temp = Mock(return_value=b"remote content")
+        runner.cleanup_temp = Mock()
+        return runner
+
+    @pytest.fixture
+    def remote_client(self, transfer_runner):
+        """PebbleCliClient backed by a mock FileTransferRunner."""
+        return PebbleCliClient(pebble_binary="mock-pebble", runner=transfer_runner)
+
+    def test_pull_text_remote_runner(self, remote_client, transfer_runner):
+        """pull() via FileTransferRunner returns a StringIO wrapping the downloaded bytes."""
+        result = remote_client.pull("/etc/hostname")
+
+        content = result.read()
+        assert content == "remote content"
+        assert isinstance(content, str)
+        # upload_temp used to create remote staging file
+        transfer_runner.upload_temp.assert_called_once_with(b"")
+        # pebble pull called with the staging path via transfer_runner.run
+        call_args = transfer_runner.run.call_args[0][0]
+        assert call_args == [
+            "mock-pebble",
+            "pull",
+            "/etc/hostname",
+            "/remote/tmp/staged",
+        ]
+        # download_temp fetches the result
+        transfer_runner.download_temp.assert_called_once_with("/remote/tmp/staged")
+        # cleanup called
+        transfer_runner.cleanup_temp.assert_called_once_with("/remote/tmp/staged")
+
+    def test_pull_binary_remote_runner(self, remote_client, transfer_runner):
+        """pull(encoding=None) via FileTransferRunner returns a BytesIO."""
+        result = remote_client.pull("/etc/hostname", encoding=None)
+
+        content = result.read()
+        assert content == b"remote content"
+        assert isinstance(content, bytes)
+
+    def test_pull_error_remote_runner_cleans_up(self, remote_client, transfer_runner):
+        """A failed pull via FileTransferRunner still calls cleanup_temp."""
+        transfer_runner.run.side_effect = subprocess.CalledProcessError(
+            1,
+            "cmd",
+            stderr="error: stat /etc/hostname: not-found - open /remote/tmp/staged: no such file or directory",
+        )
+
+        with pytest.raises(ops.pebble.PathError):
+            remote_client.pull("/etc/hostname")
+
+        transfer_runner.cleanup_temp.assert_called_once_with("/remote/tmp/staged")
+
+    def test_push_string_remote_runner(self, remote_client, transfer_runner):
+        """push() via FileTransferRunner uploads content then calls pebble push."""
+        remote_client.push("/etc/hosts", "127.0.0.1 localhost\n")
+
+        transfer_runner.upload_temp.assert_called_once_with(b"127.0.0.1 localhost\n")
+        call_args = transfer_runner.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "push", "/remote/tmp/staged", "/etc/hosts"]
+        transfer_runner.cleanup_temp.assert_called_once_with("/remote/tmp/staged")
+
+    def test_push_error_remote_runner_cleans_up(self, remote_client, transfer_runner):
+        """A failed push via FileTransferRunner still calls cleanup_temp."""
+        transfer_runner.run.side_effect = subprocess.CalledProcessError(
+            1, "cmd", stderr="error: stat /nonexistent: no such file or directory"
+        )
+
+        with pytest.raises(ops.pebble.PathError):
+            remote_client.push("/nonexistent/file", "content")
+
+        transfer_runner.cleanup_temp.assert_called_once_with("/remote/tmp/staged")
+
+    def test_push_cleanup_always_called(self, remote_client, transfer_runner):
+        """cleanup_temp is called even when cleanup is the only thing left to do."""
+        remote_client.push("/etc/hosts", b"content")
+
+        transfer_runner.cleanup_temp.assert_called_once_with("/remote/tmp/staged")
 
     def test_exec_simple(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test simple command execution."""


### PR DESCRIPTION
## Summary

- Adds a `FileTransferRunner` protocol (`upload_temp`, `download_temp`, `cleanup_temp`) so remote runners can stage temporary files on the remote host rather than assuming a shared filesystem
- `LocalSubprocessRunner` implements the new protocol — existing local-subprocess behaviour is unchanged
- `push` and `pull` detect the protocol via `hasattr` and use the runner's file-transfer methods when available, falling back to the previous `NamedTemporaryFile` path otherwise
- `FileTransferRunner` is exported from the top-level `shimmer` package

Closes #56

## Test plan

- [ ] `tox -e unit` passes (6 new tests covering remote runner paths for `pull` and `push`: text, binary, error+cleanup)
- [ ] `tox -e lint` passes