### PR TITLE
chore: prepare for 1.0.0b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2026-05-31
 
 Features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pebble-shimmer"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "A drop-in replacement for ops.pebble.Client that uses the Pebble CLI"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the version from 1.0.0b2 to 1.0.0b3 and dates the CHANGELOG section (2026-05-31). Ships the FileTransferRunner protocol (#60) so push/pull work correctly with remote runners (e.g. JujuSshRunner) that don't share a filesystem with the pebble binary.