### PR TITLE
ci: install pebble from latest/stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # The structured `--format json` flag the client relies on shipped in the
-    # candidate channel (stable soon); bump this to `latest/stable` once it lands.
     - name: Install Pebble (for integration tests)
       run: |
-        sudo snap install pebble --classic --channel=latest/candidate
+        sudo snap install pebble --classic --channel=latest/stable
         pebble version --client
 
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/.workshop/shimmer-dev/hooks/setup-base
+++ b/.workshop/shimmer-dev/hooks/setup-base
@@ -1,10 +1,9 @@
 #!/bin/bash -e
-# Integration tests need a `pebble` binary on PATH with `--format json` support.
-# When the `pebble` plug is connected, pebble-src is the mounted binary (a
-# regular executable file); setup-project puts it on PATH. When unconnected the
-# mount target is just an empty directory, so install the candidate snap, which
-# ships that flag (stable soon — bump the channel then).
+# Integration tests need a `pebble` binary on PATH. When the `pebble` plug is
+# connected, pebble-src is the mounted binary (a regular executable file);
+# setup-project puts it on PATH. When unconnected the mount target is just an
+# empty directory, so install the stable snap.
 src=/home/workshop/.local/bin/pebble-src
 if [ ! -f "$src" ] || [ ! -x "$src" ]; then
-  snap install pebble --classic --channel=latest/candidate
+  snap install pebble --classic --channel=latest/stable
 fi

--- a/.workshop/shimmer-dev/hooks/setup-project
+++ b/.workshop/shimmer-dev/hooks/setup-project
@@ -4,7 +4,7 @@ sudo -iu workshop -- bash -lc 'cd /project && uv sync'
 
 # If a built pebble was mounted via the `pebble` plug (a real executable file,
 # not the empty mount-target dir of an unconnected plug), symlink it onto PATH.
-# ~/.local/bin is first on PATH, so it takes precedence over the candidate snap.
+# ~/.local/bin is first on PATH, so it takes precedence over the stable snap.
 if [ -f /home/workshop/.local/bin/pebble-src ] && [ -x /home/workshop/.local/bin/pebble-src ]; then
   sudo -iu workshop -- bash -lc 'ln -sf ~/.local/bin/pebble-src ~/.local/bin/pebble'
 fi

--- a/.workshop/shimmer-dev/sdk.yaml
+++ b/.workshop/shimmer-dev/sdk.yaml
@@ -4,9 +4,8 @@
 #
 # Unit tests (tests/unit/) mock the CLI and need no Pebble; integration tests
 # (tests/integration/) shell out to a real `pebble` binary on PATH and assert
-# parity against the socket client. The `--format json` output the client
-# relies on shipped in Pebble's latest/candidate snap channel, which setup-base
-# installs when the `pebble` plug is unconnected.
+# parity against the socket client. setup-base installs the
+# `latest/stable` pebble snap when the `pebble` plug is unconnected.
 #
 # Relies on the `uv` SDK being present in the workshop (tox comes from the
 # project's `dev` extra, run via `uv run tox`); ~/.cache/uv is persisted by uv.
@@ -17,7 +16,7 @@ summary: In-project setup for developing shimmer
 # Optional: consume a `pebble` binary exposed by a pebble dev workshop, for the
 # integration tests. Bind project-shimmer-dev:pebble to project-pebble-dev:pebble-bin in
 # the workshop definition if you run a pebble workshop alongside (e.g. to test
-# against an unreleased pebble). Without it, setup-base installs the candidate
+# against an unreleased pebble). Without it, setup-base installs the stable
 # snap.
 plugs:
   pebble:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,7 @@ If you land a fix and the changelog wasn't touched, that's a miss — add it.
 - Unit tests (`tests/unit/`) mock the CLI and need no Pebble.
 - Integration tests (`tests/integration/`) shell out to a real `pebble` binary
   and assert parity against the socket client.
-- CI installs Pebble from the `latest/candidate` snap channel, which ships the
-  structured `--format json` output the client relies on for some read commands.
-  Bump to `latest/stable` once that release is promoted (see the note in
-  `.github/workflows/ci.yaml`).
+- CI installs Pebble from the `latest/stable` snap channel.
 
 ## CI, merging, and supply chain
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -92,11 +92,7 @@ prepare: |
 
   sudo snap install astral-uv --classic
 
-  # Pebble's structured --format json output (required by shimmer) is not yet
-  # in any released snap; build from master until a snap release ships it.
-  sudo snap install go --classic
-  GOPATH=/tmp/spread-gopath go install github.com/canonical/pebble/cmd/pebble@master
-  sudo install -m 755 /tmp/spread-gopath/bin/pebble /usr/local/bin/pebble
+  sudo snap install pebble --classic --channel=latest/stable
 
   uv sync
 

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -6,10 +6,9 @@
 # external dependency is a `pebble` binary on PATH for the integration tests,
 # which assert CLI/socket parity.
 #
-# The structured `--format json` output the client relies on shipped in Pebble's
-# `latest/candidate` snap channel (stable soon), so the in-project SDK installs
-# that snap in setup-base. To test against an unreleased pebble instead, run a
-# pebble dev workshop alongside and connect its built binary:
+# The in-project SDK installs the `latest/stable` pebble snap in setup-base. To
+# test against an unreleased pebble instead, run a pebble dev workshop
+# alongside and connect its built binary:
 #   workshop connect dev/project-shimmer-dev:pebble <pebble-workshop>/project-pebble-dev:pebble-bin
 name: dev
 base: ubuntu@24.04


### PR DESCRIPTION
## Summary
- Pebble 1.31.0 is now in `latest/stable`, so the candidate-channel and build-from-master workarounds for the structured `--format json` output are no longer needed.
- CI, spread, and workshop hooks now install `pebble --channel=latest/stable`.
- Updated AGENTS.md, workshop.yaml, and SDK comments to match.

## Test plan
- [ ] CI green on `lint`, `test (3.12)`, `test (3.13)`, `zizmor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)