### PR TITLE
test: re-enable workshop spread test

### DIFF
--- a/tests/spread/workshop/task.yaml
+++ b/tests/spread/workshop/task.yaml
@@ -1,0 +1,25 @@
+summary: Launch and exercise the workshop development environment
+
+systems:
+  - ubuntu-24.04
+
+prepare: |
+  sudo lxd init --auto
+  sudo snap install workshop --classic
+  sudo adduser spread lxd
+  # The spread framework uploads project files as root (via sudo rsync), so
+  # all files arrive owned by uid=0. Workshop's checkOwner in copySdkDir
+  # synthesises EPERM when the SDK directory owner != the invoking user's
+  # uid. Re-chown the whole tree so the check passes for the spread user.
+  sudo chown -R spread:spread "$SPREAD_PATH"
+
+execute: |
+  pushd "$SPREAD_PATH"
+  # sg lxd activates lxd group membership without requiring a re-login
+  sg lxd -c "workshop launch dev"
+  sg lxd -c "workshop run dev unit"
+  sg lxd -c "workshop run dev lint"
+  popd
+
+restore: |
+  sg lxd -c "workshop remove dev" || true


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Restores `tests/spread/workshop/task.yaml`, which was dropped in #54 because `workshop launch` was failing with EPERM on `.workshop/shimmer-dev`
- Root cause identified and fixed in the spread task's `prepare` block (no changes to library code)
- `tox -e lint` and `tox -e unit` still pass

## Root cause

The spread framework uploads project files using `sudo rsync`, which creates every file and directory owned by **root** (uid=0). Workshop's `checkOwner` function (in `internal/osutil/cp.go`) synthesises `EPERM` whenever the SDK directory's owner uid ≠ the uid of the user who ran `workshop launch` (the `spread` user). The error message seen in CI:

```
open /home/spread/shimmer/.workshop/shimmer-dev: operation not permitted
```

is not a real OS `open()` failure — it is produced unconditionally by `checkOwner` when the ownership check fails.

## Fix

In the task `prepare` block, re-chown the entire project tree to the `spread` user before calling `workshop launch`:

```bash
sudo chown -R spread:spread "$SPREAD_PATH"
```

This makes `.workshop/shimmer-dev/` owned by the `spread` user, so `checkOwner` passes and `workshop launch dev` proceeds normally.

The task also:
- Initialises LXD (`lxd init --auto`) — required for workshop to create containers
- Installs the `workshop` snap
- Adds `spread` to the `lxd` group and uses `sg lxd` to activate that membership without a re-login

## Test plan

- [ ] Spread run against the `lxd` backend completes `tests/spread/workshop` without error
- [ ] `workshop launch dev` succeeds (no EPERM)
- [ ] `workshop run dev unit` and `workshop run dev lint` both pass inside the workshop container
- [ ] `tox -e lint` passes (no regressions)
- [ ] `tox -e unit` passes (no regressions)

Closes #57

https://claude.ai/code/session_01PxZBFsUeaoxaTAqPTSWp1C
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxZBFsUeaoxaTAqPTSWp1C)_