### PR TITLE
chore(deps): pilot-mode Dependabot config for dependabot-agent step 9

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,19 +1,24 @@
+# PILOT — temporarily reduced cooldown/frequency for dependabot-agent step 9.
+# Revert after pilot exits per non-roadmap/dependabot-agent/PLAN.md in
+# canonical-work-queue. 3d cooldown is deliberately risky; pilot acceptance
+# is "agent reviews fast", not "releases are settled".
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"  # This is hard-coded to the 1st of the month
+      interval: "daily"
     cooldown:
-      default-days: 7  # Don't adopt a release until it's 7 days old.
+      default-days: 3
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 7  # Don't adopt a release until it's 7 days old.
-    open-pull-requests-limit: 0  # Security updates only
+      default-days: 3
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

- Switch Python ecosystem to `uv` (where not already) and routine `interval` to `daily`.
- Drop `cooldown` to `default-days: 3` (no per-axis bumps). **3d is deliberately risky** — pilot acceptance is "agent reviews fast", not "releases are settled".
- Replace any security-only `open-pull-requests-limit: 0` with `5` so the routine lane actually emits version-update PRs.
- `# PILOT — …` header points back to `non-roadmap/dependabot-agent/PLAN.md` in canonical-work-queue.

## Why

Feeds the local-cron `dependabot-agent` CLI pilot (step 9). Without this, three of four personal repos emit only Dependabot security PRs (rare), so the agent has nothing to review.

## Revert

At pilot exit (≥20 PRs reviewed or two clean weeks per the PLAN's exit criteria).