### PR TITLE
feat: Adopt structured output for get_system_info and get_warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 2026-07-14
+
+Features:
+
+- `get_system_info()` now uses `pebble version --format json` and returns
+  the daemon's (server) version, matching `ops.pebble.Client` (which reads
+  the same value from `/v1/system-info`). Previously shimmer returned the
+  CLI binary's own version via `pebble version --client`. This requires
+  Pebble v1.32.0 or later.
+- `get_warnings()` is now implemented on top of `pebble warnings --format
+  json` (added in Pebble v1.31.0): warnings are surfaced by Pebble as
+  notices of type `warning`, and shimmer maps them back to
+  `ops.pebble.Warning` for drop-in parity. `ack_warnings()` continues to
+  raise `NotImplementedError` because `pebble okay` acks by local CLI
+  state rather than by timestamp.
+
+Bug fixes and packaging:
+
+- The minimum supported Pebble version is now v1.32.0, in line with the
+  structured-output requirement `get_system_info()` now shares with the
+  other read methods.
+
 # 2026-06-05
 
 Shimmer 1.0.0. The `PebbleCliClient` API is now stable: it matches

--- a/README.md
+++ b/README.md
@@ -98,15 +98,20 @@ A few methods can't fully match the socket client:
   `pebble notify` for custom notices).
 - `abort_change()` raises `NotImplementedError`: the Pebble CLI exposes no
   command to abort a change, so there is no way to back this through the CLI.
-- `get_warnings()` and `ack_warnings()` raise `NotImplementedError`: warnings
-  are deprecated in Pebble (the warnings API has been removed and warnings are
-  now surfaced as notices). Use `get_notices()` / `get_notice()` instead.
+- `get_warnings()` works by reading `pebble warnings --format json` (Pebble
+  surfaces warnings as notices of type `warning`) and mapping the result back
+  to `ops.pebble.Warning`, so it stays drop-in with `ops.pebble.Client`.
+  `ack_warnings()` still raises `NotImplementedError`: `pebble okay` acks by
+  local CLI state, not by timestamp, so ops's timestamp semantics cannot be
+  reproduced.
 
-`get_services()`, `get_checks()`, `list_files()`, `get_changes()`,
-`get_change()`, and `get_identities()` use Pebble's structured `--format json`
-output, so they return the same rich data as `ops.pebble.Client` (change
-`kind`/`tasks`/`err`, check thresholds, real file ownership, local identity user
-IDs). This requires a Pebble build that supports `--format` on read commands.
+`get_system_info()`, `get_services()`, `get_checks()`, `list_files()`,
+`get_changes()`, `get_change()`, `get_notices()`, `get_notice()`,
+`get_warnings()`, and `get_identities()` use Pebble's structured `--format
+json` output, so they return the same rich data as `ops.pebble.Client` (change
+`kind`/`tasks`/`err`, check thresholds, real file ownership, local identity
+user IDs). This requires Pebble v1.32.0 or later (which added `--format` to
+`pebble version`).
 
 ## Comparison with `ops.pebble.Client`
 

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -176,9 +176,12 @@ class PebbleCliClient:
 
     def get_system_info(self) -> SystemInfo:
         """Get system information."""
-        result = self._run_command(["version", "--client"])
-        lines = result.stdout.strip().split("\n")
-        return SystemInfo(lines[0].strip())
+        # Requires Pebble >= v1.32.0, which added ``--format json`` to
+        # ``pebble version``. Emits ``{"client": ..., "server": ...}``; the
+        # ``server`` field is the daemon version, matching what ops.pebble
+        # returns from ``/v1/system-info``.
+        data = self._run_json(["version"])
+        return SystemInfo(version=data["server"])
 
     def add_layer(
         self,
@@ -897,31 +900,53 @@ class PebbleCliClient:
         # The output looks like: "Recorded notice 38"
         return result.stdout.strip().split()[-1]
 
-    # Warnings are deprecated in Pebble: the warnings API endpoint has been
-    # removed (warnings are now surfaced as notices), and the `pebble okay` CLI
-    # has stateful, timestamp-free semantics that cannot reproduce
-    # ops.pebble.Client's by-timestamp acknowledgement. Rather than return a
-    # silently-empty list or a misleading count, shimmer reports clearly that
-    # warnings are unsupported. Use the notices methods instead.
-    _WARNINGS_UNSUPPORTED = (
-        "Pebble has deprecated warnings (the warnings API has been removed and "
-        "warnings are now surfaced as notices), so shimmer does not support "
-        "{method}. Use get_notices()/get_notice() instead."
-    )
-
     def get_warnings(
         self,
         select: WarningState = WarningState.PENDING,
     ) -> list[Warning]:
-        """Unsupported: warnings are deprecated in Pebble (see get_notices)."""
-        raise NotImplementedError(
-            self._WARNINGS_UNSUPPORTED.format(method="get_warnings()")
-        )
+        """Get list of warnings in given state (pending or all).
+
+        Under the hood, Pebble surfaces warnings as notices of type ``warning``.
+        ``pebble warnings --format json`` (added in Pebble v1.31.0) emits the
+        matching notices, which we map back to ``ops.pebble.Warning`` for
+        drop-in compatibility with ``ops.pebble.Client``.
+        """
+        cmd = ["warnings"]
+        if select == WarningState.ALL:
+            cmd.append("--all")
+        data = self._run_json(cmd)
+        if not data:
+            return []
+        warnings: list[Warning] = []
+        for notice in data.get("warnings", []):
+            # The notice's ``key`` is the warning body; the ``occurred`` fields
+            # map to the ops ``added`` fields. ``last-shown`` is a per-client
+            # concept that Pebble tracks in local CLI state rather than on the
+            # notice, so it's left unset.
+            warnings.append(
+                Warning.from_dict(
+                    {
+                        "message": notice["key"],
+                        "first-added": notice["first-occurred"],
+                        "last-added": notice["last-occurred"],
+                        "expire-after": notice.get("expire-after", ""),
+                        "repeat-after": notice.get("repeat-after", ""),
+                    }
+                )
+            )
+        return warnings
 
     def ack_warnings(self, timestamp: datetime.datetime) -> int:
-        """Unsupported: warnings are deprecated in Pebble (see get_notices)."""
+        """Unsupported: ``pebble okay`` acks stateful, not by timestamp."""
+        # The socket client POSTs {"action": "okay", "timestamp": ...} to
+        # /v1/warnings; the CLI's ``pebble okay`` acks whatever the local CLI
+        # state file marks as "last listed" and takes no timestamp argument, so
+        # we can't reproduce the by-timestamp semantics ops.pebble.Client
+        # promises. Rather than silently ack the wrong set, we surface this.
         raise NotImplementedError(
-            self._WARNINGS_UNSUPPORTED.format(method="ack_warnings()")
+            "ack_warnings() cannot be implemented via the pebble CLI: "
+            "`pebble okay` acks by local CLI state, not by timestamp. "
+            "Use the socket client if you need timestamp-based acking."
         )
 
     def get_identities(self) -> dict[str, Identity]:

--- a/tests/integration/test_parity.py
+++ b/tests/integration/test_parity.py
@@ -326,10 +326,12 @@ class TestNoticeParity:
         assert_parity(s, c, drop={"id"})
 
 
-# Warnings have no parity tests: they are deprecated in Pebble (the API
-# endpoint is removed) and shimmer intentionally raises NotImplementedError for
-# get_warnings()/ack_warnings(). That documented behaviour is covered by a
-# unit test (tests/unit/test_client.py::...::test_warnings_unsupported).
+# get_warnings() has no parity test: ops.pebble.Client hits /v1/warnings which
+# modern Pebble no longer serves (warnings are surfaced as notices), so the
+# socket client raises APIError(404) while shimmer returns a translated list.
+# The CLI-side behaviour is covered by unit tests. ack_warnings() likewise has
+# no parity: `pebble okay` cannot honour ops's timestamp semantics, so shimmer
+# raises NotImplementedError (covered by test_ack_warnings_unsupported).
 
 
 class TestIdentityParity:

--- a/tests/integration/test_shimmer.py
+++ b/tests/integration/test_shimmer.py
@@ -64,9 +64,9 @@ def running_pebble(
             stderr=subprocess.DEVNULL,
         )
 
-        # Probe with a command that actually contacts the daemon (get_services
-        # hits the socket); get_system_info only runs `version --client`, which
-        # succeeds before the daemon is listening.
+        # Probe with a command that actually contacts the daemon. (get_services
+        # and get_system_info both do, since v1.32.0's `version --format json`
+        # reads the server version.)
         for attempt in range(60):
             try:
                 pebble_client.get_services()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -183,13 +183,16 @@ class TestPebbleCliClient:
 
     def test_get_system_info(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting system information."""
-        mock_subprocess.run.return_value.stdout = "v1.0.0\n"
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {"client": "v1.32.0", "server": "v1.32.0"}
+        )
 
         info = client.get_system_info()
 
-        assert info.version == "v1.0.0"
+        # Mirror ops.pebble.Client, which returns the daemon (server) version.
+        assert info.version == "v1.32.0"
         mock_subprocess.run.assert_called_once_with(
-            ["mock-pebble", "version", "--client"],
+            ["mock-pebble", "version", "--format", "json"],
             input=None,
             capture_output=True,
             text=True,
@@ -198,15 +201,17 @@ class TestPebbleCliClient:
             check=True,
         )
 
-    def test_get_system_info_multiline_output(
+    def test_get_system_info_server_differs_from_client(
         self, mock_subprocess: Mock, client: PebbleCliClient
     ):
-        """Only the first line of `version --client` output is used."""
-        mock_subprocess.run.return_value.stdout = "v1.2.3\nextra trailing line\n"
+        """When client and server versions differ, the server version wins."""
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {"client": "v1.32.0", "server": "v1.30.1"}
+        )
 
         info = client.get_system_info()
 
-        assert info.version == "v1.2.3"
+        assert info.version == "v1.30.1"
 
     def test_add_layer_string(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test adding a layer from string."""
@@ -1143,11 +1148,59 @@ class TestPebbleCliClient:
         with pytest.raises(ValueError, match="Only custom notices are supported"):
             client.notify(ops.pebble.NoticeType.CHANGE_UPDATE, "some-key")
 
-    def test_warnings_unsupported(self, client: PebbleCliClient):
-        """Warnings are deprecated in Pebble; both methods raise clearly."""
-        with pytest.raises(NotImplementedError, match="deprecated"):
-            client.get_warnings()
-        with pytest.raises(NotImplementedError, match="deprecated"):
+    def test_get_warnings(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """get_warnings maps `pebble warnings --format json` output to Warning."""
+        mock_subprocess.run.return_value.stdout = json.dumps(
+            {
+                "warnings": [
+                    {
+                        "id": "1",
+                        "user-id": None,
+                        "type": "warning",
+                        "key": "something is off",
+                        "first-occurred": "2026-07-14T12:00:00Z",
+                        "last-occurred": "2026-07-14T12:05:00Z",
+                        "last-repeated": "2026-07-14T12:05:00Z",
+                        "occurrences": 2,
+                        "expire-after": "672h0m0s",
+                        "repeat-after": "24h0m0s",
+                    }
+                ]
+            }
+        )
+
+        warnings = client.get_warnings()
+
+        assert len(warnings) == 1
+        w = warnings[0]
+        assert w.message == "something is off"
+        assert w.first_added == datetime.datetime(
+            2026, 7, 14, 12, 0, 0, tzinfo=datetime.UTC
+        )
+        assert w.last_added == datetime.datetime(
+            2026, 7, 14, 12, 5, 0, tzinfo=datetime.UTC
+        )
+        assert w.last_shown is None
+        assert w.expire_after == "672h0m0s"
+        assert w.repeat_after == "24h0m0s"
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "warnings", "--format", "json"]
+
+    def test_get_warnings_all(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """WarningState.ALL passes --all through to the CLI."""
+        mock_subprocess.run.return_value.stdout = json.dumps({"warnings": []})
+        client.get_warnings(select=ops.pebble.WarningState.ALL)
+        call_args = mock_subprocess.run.call_args[0][0]
+        assert call_args == ["mock-pebble", "warnings", "--all", "--format", "json"]
+
+    def test_get_warnings_empty(self, mock_subprocess: Mock, client: PebbleCliClient):
+        """No warnings surfaces as an empty list, not an error."""
+        mock_subprocess.run.return_value.stdout = json.dumps({"warnings": []})
+        assert client.get_warnings() == []
+
+    def test_ack_warnings_unsupported(self, client: PebbleCliClient):
+        """`pebble okay` has no timestamp arg, so we can't preserve semantics."""
+        with pytest.raises(NotImplementedError, match="timestamp"):
             client.ack_warnings(datetime.datetime.now(datetime.UTC))
 
     def test_abort_change_unsupported(self, client: PebbleCliClient):
@@ -1265,7 +1318,7 @@ class TestRunnerInjection:
                 captured["argv"] = argv
                 captured["env"] = env
                 result = MagicMock()
-                result.stdout = "v1.2.3\n"
+                result.stdout = json.dumps({"client": "v1.2.3", "server": "v1.2.3"})
                 result.stderr = ""
                 result.returncode = 0
                 return result
@@ -1279,7 +1332,7 @@ class TestRunnerInjection:
         info = client.get_system_info()
 
         assert info.version == "v1.2.3"
-        assert captured["argv"] == ["my-pebble", "version", "--client"]
+        assert captured["argv"] == ["my-pebble", "version", "--format", "json"]
         assert captured["env"] is client._env
 
         # Structural check: FakeRunner satisfies the Runner protocol.


### PR DESCRIPTION
Pebble v1.32.0 added --format json to `pebble version`, and v1.31.0 added it to `pebble warnings`. Adopt both:

- get_system_info() now runs `pebble version --format json` and returns the server (daemon) version, matching what ops.pebble.Client reads from /v1/system-info. Previously we returned the CLI binary's version via --client, which diverged from ops when the binary and daemon disagreed.
- get_warnings() is now implemented on top of `pebble warnings --format json`. Pebble surfaces warnings as notices of type "warning", so we map notice fields back into ops.pebble.Warning for drop-in parity. ack_warnings() still raises NotImplementedError: `pebble okay` acks by local CLI state, not by timestamp.

Bump the documented minimum Pebble to v1.32.0 to match.

Refs #95