### PR TITLE
style: Standardise ruff configuration and fix all findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ directory (or pass `socket_path=`); check `pebble version`.
 
 ```python
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 ```
 

--- a/demo.py
+++ b/demo.py
@@ -69,7 +69,7 @@ def _socket_path() -> str:
 
 
 def socket_client() -> ops.pebble.Client:
-    """The real ops client, talking to the daemon over its unix socket."""
+    """Return the real ops client, talking to the daemon over its unix socket."""
     return ops.pebble.Client(socket_path=_socket_path())
 
 
@@ -140,9 +140,7 @@ def _find(getter, name: str):
 def curl_status(url: str = HTTP_URL) -> str:
     """Return the HTTP status line, retrying while the server comes up."""
     for _ in range(20):
-        proc = subprocess.run(
-            ["curl", "-s", "-i", "-m", "2", url], capture_output=True, text=True
-        )
+        proc = subprocess.run(["curl", "-s", "-i", "-m", "2", url], capture_output=True, text=True)
         first = proc.stdout.splitlines()[0].strip() if proc.stdout else ""
         if first.startswith("HTTP"):
             return first
@@ -230,51 +228,70 @@ def build_demo() -> bool:
     showboat("init", DEMO_FILE, "Shimmer: a drop-in Pebble client over the CLI")
 
     steps: list[tuple[str, ...]] = [
-        ("note",
-         "**Shimmer** provides `PebbleCliClient`, a drop-in replacement for "
-         "`ops.pebble.Client` that drives Pebble through its **CLI** instead of "
-         "the unix socket — for environments where the socket isn't reachable. "
-         "The contract is *parity*: same methods, same return types, same "
-         "exceptions. This document proves it."),
-
+        (
+            "note",
+            "**Shimmer** provides `PebbleCliClient`, a drop-in replacement for "
+            "`ops.pebble.Client` that drives Pebble through its **CLI** instead of "
+            "the unix socket — for environments where the socket isn't reachable. "
+            "The contract is *parity*: same methods, same return types, same "
+            "exceptions. This document proves it.",
+        ),
         ("note", "## The claim, proven"),
-        ("note",
-         "We run one deploy-and-verify routine against the **real socket "
-         "client**, then the **exact same routine** against Shimmer, and compare "
-         "the results. First, `ops.pebble.Client` over the unix socket:"),
-        ("exec", "bash", _py(
-            "from demo import socket_client, run_and_capture\n"
-            "run_and_capture(socket_client(), '/tmp/shimmer-parity/socket.txt')")),
-
-        ("note",
-         "Now the **same code**, but through `shimmer.PebbleCliClient`. The "
-         "dimmed `$ pebble …` lines are the actual commands it shells out:"),
-        ("exec", "bash", _py(
-            "from demo import cli_client, run_and_capture\n"
-            "run_and_capture(cli_client(trace=True), '/tmp/shimmer-parity/cli.txt')")),
-
+        (
+            "note",
+            "We run one deploy-and-verify routine against the **real socket "
+            "client**, then the **exact same routine** against Shimmer, and compare "
+            "the results. First, `ops.pebble.Client` over the unix socket:",
+        ),
+        (
+            "exec",
+            "bash",
+            _py(
+                "from demo import socket_client, run_and_capture\n"
+                "run_and_capture(socket_client(), '/tmp/shimmer-parity/socket.txt')"
+            ),
+        ),
+        (
+            "note",
+            "Now the **same code**, but through `shimmer.PebbleCliClient`. The "
+            "dimmed `$ pebble …` lines are the actual commands it shells out:",
+        ),
+        (
+            "exec",
+            "bash",
+            _py(
+                "from demo import cli_client, run_and_capture\n"
+                "run_and_capture(cli_client(trace=True), '/tmp/shimmer-parity/cli.txt')"
+            ),
+        ),
         ("note", "## Identical results"),
-        ("note",
-         "Two transports, one set of outputs. `diff` finds nothing to report:"),
-        ("exec", "bash",
-         "diff /tmp/shimmer-parity/socket.txt /tmp/shimmer-parity/cli.txt "
-         "&& echo 'PARITY: identical ✓'"),
-
+        ("note", "Two transports, one set of outputs. `diff` finds nothing to report:"),
+        (
+            "exec",
+            "bash",
+            "diff /tmp/shimmer-parity/socket.txt /tmp/shimmer-parity/cli.txt "
+            "&& echo 'PARITY: identical ✓'",
+        ),
         ("note", "## The service is really running"),
-        ("note",
-         "The deployed layer runs `python3 -m http.server`. That's a real "
-         "process serving real traffic — here's the live response (the "
-         "volatile `Date` header is filtered so the document stays verifiable):"),
-        ("exec", "bash",
-         f"curl -s -i {HTTP_URL} | tr -d '\\r' | grep -vi '^date:' | head -3"),
-
+        (
+            "note",
+            "The deployed layer runs `python3 -m http.server`. That's a real "
+            "process serving real traffic — here's the live response (the "
+            "volatile `Date` header is filtered so the document stays verifiable):",
+        ),
+        ("exec", "bash", f"curl -s -i {HTTP_URL} | tr -d '\\r' | grep -vi '^date:' | head -3"),
         ("note", "## Cleanup"),
-        ("exec", "bash", _py(
-            "from demo import cli_client\n"
-            "c = cli_client()\n"
-            "c.stop_services(['demo-server'])\n"
-            "print('demo-server:', "
-            "next(s for s in c.get_services() if s.name == 'demo-server').current.value)")),
+        (
+            "exec",
+            "bash",
+            _py(
+                "from demo import cli_client\n"
+                "c = cli_client()\n"
+                "c.stop_services(['demo-server'])\n"
+                "print('demo-server:', "
+                "next(s for s in c.get_services() if s.name == 'demo-server').current.value)"
+            ),
+        ),
     ]
 
     ok = True
@@ -359,11 +376,17 @@ tmux attach -t "$S"
     print(f"Recording tmux side-by-side to {CAST_FILE} ...")
     subprocess.run(
         [
-            "asciinema", "rec",
-            "--cols", "200", "--rows", "50",
-            "--idle-time-limit", "2",
+            "asciinema",
+            "rec",
+            "--cols",
+            "200",
+            "--rows",
+            "50",
+            "--idle-time-limit",
+            "2",
             "--overwrite",
-            "--command", f"bash {driver}",
+            "--command",
+            f"bash {driver}",
             CAST_FILE,
         ],
         check=True,
@@ -376,17 +399,24 @@ tmux attach -t "$S"
 # --------------------------------------------------------------------------- #
 def main() -> None:
     parser = argparse.ArgumentParser(description="Shimmer parity demo")
-    parser.add_argument("--client", choices=["socket", "cli"],
-                        help="run the workload via one client (used by the tmux panes)")
+    parser.add_argument(
+        "--client",
+        choices=["socket", "cli"],
+        help="run the workload via one client (used by the tmux panes)",
+    )
     parser.add_argument("--results", help="write canonical result lines here")
-    parser.add_argument("--record", action="store_true",
-                        help="record the tmux side-by-side comparison")
+    parser.add_argument(
+        "--record", action="store_true", help="record the tmux side-by-side comparison"
+    )
     args = parser.parse_args()
 
     if args.client:
         client = socket_client() if args.client == "socket" else cli_client(trace=True)
-        header = ("ops.pebble.Client  (unix socket)" if args.client == "socket"
-                  else "shimmer.PebbleCliClient  (CLI)")
+        header = (
+            "ops.pebble.Client  (unix socket)"
+            if args.client == "socket"
+            else "shimmer.PebbleCliClient  (CLI)"
+        )
         say(f"=== {header} ===\n")
         if args.results:
             run_and_capture(client, args.results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
-    "ruff==0.15.21",
+    "ruff==0.16.0",
     "ty==0.0.61",
     "tox>=4.0.0",
     "pre-commit>=3.0.0",
@@ -60,35 +60,6 @@ include = [
 ]
 
 # Ruff configuration
-[tool.ruff]
-line-length = 88
-target-version = "py311"
-src = ["src", "tests"]
-
-[tool.ruff.lint]
-select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "UP", # pyupgrade
-    "N",  # pep8-naming
-]
-ignore = [
-    "E501",  # line too long, handled by formatter
-    "B008",  # do not perform function calls in argument defaults
-    "C901",  # too complex
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/*" = ["N802", "N803", "N806"]  # Allow non-lowercase variable names in tests
-
-[tool.ruff.lint.isort]
-known-first-party = ["shimmer"]
-
-# Pytest configuration
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = [
@@ -130,3 +101,56 @@ precision = 2
 
 [tool.coverage.html]
 directory = "htmlcov"
+
+[tool.ruff]
+line-length = 99
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "F",
+    "E",
+    "W",
+    "I",
+    "N",
+    "A",
+    "UP",
+    "YTT",
+    "S",
+    "B",
+    "SIM",
+    "RUF",
+    "PERF",
+    "D",
+    "FA",
+    "TC",
+]
+ignore = [
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+    "E501",
+    "B008",
+    # Method docstrings are not mandated; module/class/function docs are.
+    "D102",
+    # This tool deliberately shells out to juju/charmcraft/snap.
+    "S603",
+    "S607",
+    # Mirrors the ops.pebble API surface (id/type/input, ConnectionError).
+    "A002",
+    "A004",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"demo.py" = ["S108", "S103", "D103"]  # A throwaway demo script, not shipped code.
+"**/tests/**" = ["S101", "S105", "S106", "S108", "PLR2004", "ARG", "SLF001", "N802", "N803", "N806", "D"]

--- a/src/shimmer/__init__.py
+++ b/src/shimmer/__init__.py
@@ -20,7 +20,10 @@ from ._process import ExecProcess
 from ._protocol import PebbleClientProtocol
 from ._runner import FileTransferRunner, LocalSubprocessRunner, Runner
 
-__all__ = [
+# Grouped by origin rather than sorted: shimmer's own API first, then the
+# ops.pebble exceptions re-exported for drop-in compatibility (with the base
+# ``Error`` leading its group).
+__all__ = [  # noqa: RUF022
     "PebbleCliClient",
     "ExecProcess",
     "FileTransferRunner",

--- a/src/shimmer/_client.py
+++ b/src/shimmer/_client.py
@@ -1,4 +1,4 @@
-"""Shimmer - shiny Pebble client
+"""Shimmer - shiny Pebble client.
 
 This module provides a PebbleCliClient class that implements the same interface as
 ops.pebble.Client but communicates with Pebble via CLI commands instead of via a
@@ -7,7 +7,6 @@ socket.
 
 from __future__ import annotations
 
-import datetime
 import fnmatch
 import io
 import json
@@ -17,8 +16,7 @@ import signal
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterable, Mapping
-from typing import Any, BinaryIO, NoReturn, TextIO, cast, overload
+from typing import TYPE_CHECKING, Any, BinaryIO, NoReturn, TextIO, cast, overload
 
 import yaml
 
@@ -51,6 +49,10 @@ from ops.pebble import (
 
 from ._process import ExecProcess
 from ._runner import FileTransferRunner, LocalSubprocessRunner, Runner
+
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Iterable, Mapping
 
 
 class PebbleCliClient:
@@ -91,7 +93,7 @@ class PebbleCliClient:
         check: bool = True,
     ) -> subprocess.CompletedProcess[Any]:
         """Run a pebble CLI command and return the result."""
-        full_cmd = [self.pebble_binary] + cmd
+        full_cmd = [self.pebble_binary, *cmd]
 
         try:
             result = self._runner.run(
@@ -107,9 +109,7 @@ class PebbleCliClient:
         except subprocess.TimeoutExpired as e:
             raise TimeoutError(f"Command {full_cmd} timed out") from e
         except FileNotFoundError as e:
-            raise ConnectionError(
-                f"Pebble binary not found: {self.pebble_binary}"
-            ) from e
+            raise ConnectionError(f"Pebble binary not found: {self.pebble_binary}") from e
 
     # Substrings used to recover the HTTP status the *socket* client would have
     # surfaced. The CLI only prints ``error: <message>`` and exits non-zero, so
@@ -192,7 +192,7 @@ class PebbleCliClient:
     ):
         """Add a configuration layer."""
         if hasattr(layer, "to_yaml"):
-            assert isinstance(layer, Layer)  # Unpythonic, but makes the linters happy.
+            assert isinstance(layer, Layer)  # noqa: S101  # Type narrowing for the checker.
             layer_yaml = layer.to_yaml()
         elif isinstance(layer, dict):
             layer_yaml = yaml.dump(layer)
@@ -344,7 +344,7 @@ class PebbleCliClient:
                 raise ValueError(f"Invalid signal name: {sig}")
             sig_name = full_name
         # Pebble's CLI expects the bare, uppercase signal name (e.g. "HUP").
-        cmd = ["signal", sig_name[3:]] + service_list
+        cmd = ["signal", sig_name[3:], *service_list]
         self._run_command(cmd)
 
     def get_checks(
@@ -419,11 +419,7 @@ class PebbleCliClient:
             kind = "not-found"
         elif "permission denied" in text:
             kind = "permission-denied"
-        elif (
-            "not a directory" in text
-            or "is a directory" in text
-            or "already exists" in text
-        ):
+        elif "not a directory" in text or "is a directory" in text or "already exists" in text:
             kind = "generic"
         else:
             raise error
@@ -508,11 +504,9 @@ class PebbleCliClient:
         encoding: str | None = "utf-8",
     ) -> TextIO | BinaryIO:
         """Read a file from the remote system."""
-        if hasattr(self._runner, "upload_temp") and hasattr(
-            self._runner, "download_temp"
-        ):
+        if hasattr(self._runner, "upload_temp") and hasattr(self._runner, "download_temp"):
             return self._pull_via_runner(
-                cast(FileTransferRunner, self._runner), path, encoding=encoding
+                cast("FileTransferRunner", self._runner), path, encoding=encoding
             )
         return self._pull_local(path, encoding=encoding)
 
@@ -564,10 +558,11 @@ class PebbleCliClient:
             tmp_path.unlink(missing_ok=True)
             raise
 
+        # The caller owns this handle, so it cannot be opened in a `with` block.
         handle: TextIO | BinaryIO = (
-            open(tmp_name, "rb")
+            open(tmp_name, "rb")  # noqa: SIM115
             if encoding is None
-            else open(tmp_name, encoding=encoding, newline="")
+            else open(tmp_name, encoding=encoding, newline="")  # noqa: SIM115
         )
         tmp_path.unlink(missing_ok=True)
         return handle
@@ -586,10 +581,7 @@ class PebbleCliClient:
         group: str | None = None,
     ) -> None:
         """Write content to a file on the remote system."""
-        if isinstance(source, str | bytes):
-            content = source
-        else:
-            content = source.read()
+        content = source if isinstance(source, str | bytes) else source.read()
         if isinstance(content, str):
             content = content.encode(encoding)
 
@@ -608,7 +600,7 @@ class PebbleCliClient:
             cmd.extend(["--gid", str(group_id)])
 
         if hasattr(self._runner, "upload_temp"):
-            runner = cast(FileTransferRunner, self._runner)
+            runner = cast("FileTransferRunner", self._runner)
             tmp_path = runner.upload_temp(content)
             try:
                 cmd.insert(1, tmp_path)
@@ -720,28 +712,21 @@ class PebbleCliClient:
         # Prepare stdin content
         stdin_content = None
         if stdin is not None:
-            if isinstance(stdin, str | bytes):
-                stdin_content = stdin
-            else:
-                stdin_content = stdin.read()
+            stdin_content = stdin if isinstance(stdin, str | bytes) else stdin.read()
 
             if isinstance(stdin_content, str) and encoding is None:
                 stdin_content = stdin_content.encode()
             elif isinstance(stdin_content, bytes) and encoding:
                 stdin_content = stdin_content.decode(encoding)
-            assert isinstance(stdin_content, (str | bytes))
+            assert isinstance(stdin_content, (str | bytes))  # noqa: S101  # Type narrowing.
 
         # Start the process
-        full_cmd = [self.pebble_binary] + cmd
+        full_cmd = [self.pebble_binary, *cmd]
 
         # Determine stdio handling
-        process_stdin = (
-            subprocess.PIPE if stdin_content is not None or stdin is None else None
-        )
+        process_stdin = subprocess.PIPE if stdin_content is not None or stdin is None else None
         process_stdout = subprocess.PIPE if stdout is None else stdout
-        process_stderr = (
-            subprocess.PIPE if stderr is None and not combine_stderr else stderr
-        )
+        process_stderr = subprocess.PIPE if stderr is None and not combine_stderr else stderr
 
         if combine_stderr and stderr is None:
             process_stderr = subprocess.STDOUT
@@ -756,9 +741,7 @@ class PebbleCliClient:
                 env=self._env,
             )
         except FileNotFoundError as e:
-            raise ConnectionError(
-                f"Pebble binary not found: {self.pebble_binary}"
-            ) from e
+            raise ConnectionError(f"Pebble binary not found: {self.pebble_binary}") from e
 
         return ExecProcess(
             command=command,
@@ -840,9 +823,7 @@ class PebbleCliClient:
             if change.ready:
                 return change
             if deadline is not None and time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"timed out waiting for change {change_id} ({timeout} seconds)"
-                )
+                raise TimeoutError(f"timed out waiting for change {change_id} ({timeout} seconds)")
             time.sleep(delay)
 
     def get_notices(
@@ -917,24 +898,22 @@ class PebbleCliClient:
         data = self._run_json(cmd)
         if not data:
             return []
-        warnings: list[Warning] = []
-        for notice in data.get("warnings", []):
-            # The notice's ``key`` is the warning body; the ``occurred`` fields
-            # map to the ops ``added`` fields. ``last-shown`` is a per-client
-            # concept that Pebble tracks in local CLI state rather than on the
-            # notice, so it's left unset.
-            warnings.append(
-                Warning.from_dict(
-                    {
-                        "message": notice["key"],
-                        "first-added": notice["first-occurred"],
-                        "last-added": notice["last-occurred"],
-                        "expire-after": notice.get("expire-after", ""),
-                        "repeat-after": notice.get("repeat-after", ""),
-                    }
-                )
+        # The notice's ``key`` is the warning body; the ``occurred`` fields map to
+        # the ops ``added`` fields. ``last-shown`` is a per-client concept that
+        # Pebble tracks in local CLI state rather than on the notice, so it's left
+        # unset.
+        return [
+            Warning.from_dict(
+                {
+                    "message": notice["key"],
+                    "first-added": notice["first-occurred"],
+                    "last-added": notice["last-occurred"],
+                    "expire-after": notice.get("expire-after", ""),
+                    "repeat-after": notice.get("repeat-after", ""),
+                }
             )
-        return warnings
+            for notice in data.get("warnings", [])
+        ]
 
     def ack_warnings(self, timestamp: datetime.datetime) -> int:
         """Unsupported: ``pebble okay`` acks stateful, not by timestamp."""
@@ -955,8 +934,7 @@ class PebbleCliClient:
         if not data:
             return {}
         return {
-            name: Identity.from_dict(identity)
-            for name, identity in data["identities"].items()
+            name: Identity.from_dict(identity) for name, identity in data["identities"].items()
         }
 
     def replace_identities(

--- a/src/shimmer/_process.py
+++ b/src/shimmer/_process.py
@@ -127,7 +127,7 @@ class ExecProcess:
         """Send signal to the running process."""
         if isinstance(sig, str):
             sig = getattr(signal, sig.upper())
-            assert isinstance(sig, int)
+            assert isinstance(sig, int)  # noqa: S101  # Type narrowing.
 
         if not self._finished:
             self._process.send_signal(sig)

--- a/src/shimmer/_protocol.py
+++ b/src/shimmer/_protocol.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-import datetime
-import urllib.request
-from collections.abc import Iterable, Mapping
-from typing import Any, BinaryIO, Protocol, TextIO, overload
+from typing import TYPE_CHECKING, Any, BinaryIO, Protocol, TextIO, overload
 
 import ops
+
+if TYPE_CHECKING:
+    import datetime
+    import urllib.request
+    from collections.abc import Iterable, Mapping
 
 
 class PebbleClientProtocol(Protocol):
@@ -75,17 +77,13 @@ class PebbleClientProtocol(Protocol):
         combine: bool = False,
     ): ...
     def get_plan(self) -> ops.pebble.Plan: ...
-    def get_services(
-        self, names: Iterable[str] | None = None
-    ) -> list[ops.pebble.ServiceInfo]: ...
+    def get_services(self, names: Iterable[str] | None = None) -> list[ops.pebble.ServiceInfo]: ...
 
     @overload
     def pull(self, path: str, *, encoding: None) -> BinaryIO: ...
     @overload
     def pull(self, path: str, *, encoding: str = "utf-8") -> TextIO: ...
-    def pull(
-        self, path: str, *, encoding: str | None = "utf-8"
-    ) -> BinaryIO | TextIO: ...
+    def pull(self, path: str, *, encoding: str | None = "utf-8") -> BinaryIO | TextIO: ...
 
     def push(
         self,

--- a/src/shimmer/_runner.py
+++ b/src/shimmer/_runner.py
@@ -14,8 +14,10 @@ import os
 import pathlib
 import subprocess
 import tempfile
-from collections.abc import Mapping
-from typing import IO, Any, Protocol, runtime_checkable
+from typing import IO, TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 @runtime_checkable

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,16 +20,18 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import enum
-import pathlib
 import subprocess
 import time
-from collections.abc import Callable, Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import ops
 import pytest
 
 from shimmer import PebbleCliClient
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Callable, Generator
 
 pytestmark = pytest.mark.integration
 
@@ -166,13 +168,9 @@ def _twin_daemons(
     """Boot two identical daemons from ``layer`` and yield matched clients."""
     processes: list[subprocess.Popen[bytes]] = []
     try:
-        socket_proc, socket_path = _start_daemon(
-            pebble_binary, tmp_path / "socket", layer
-        )
+        socket_proc, socket_path = _start_daemon(pebble_binary, tmp_path / "socket", layer)
         processes.append(socket_proc)
-        cli_proc, cli_socket_path = _start_daemon(
-            pebble_binary, tmp_path / "cli", layer
-        )
+        cli_proc, cli_socket_path = _start_daemon(pebble_binary, tmp_path / "cli", layer)
         processes.append(cli_proc)
 
         socket_client = ops.pebble.Client(socket_path=socket_path)
@@ -198,9 +196,7 @@ def twins(pebble_binary: str, tmp_path: pathlib.Path) -> Generator[Twins, None, 
 
 
 @pytest.fixture
-def twins_no_checks(
-    pebble_binary: str, tmp_path: pathlib.Path
-) -> Generator[Twins, None, None]:
+def twins_no_checks(pebble_binary: str, tmp_path: pathlib.Path) -> Generator[Twins, None, None]:
     """Two identical Pebble daemons with no health checks.
 
     Use for change-list comparisons, where recurring check changes would
@@ -280,7 +276,7 @@ def capture_exc(client: Any, op: Callable[[Any], Any]) -> BaseException | None:
     """Run ``op(client)`` and return the exception it raised, or None."""
     try:
         op(client)
-    except BaseException as exc:  # noqa: BLE001 - we re-inspect the type
+    except BaseException as exc:
         return exc
     return None
 
@@ -316,14 +312,13 @@ def assert_same_outcome(
     def outcome(client: Any) -> tuple[str, Any]:
         try:
             return ("returned", op(client))
-        except BaseException as exc:  # noqa: BLE001
+        except BaseException as exc:
             return ("raised", exc)
 
     socket_kind, socket_val = outcome(twins.socket)
     cli_kind, cli_val = outcome(twins.cli)
     assert socket_kind == cli_kind, (
-        f"outcome mismatch: socket {socket_kind} {socket_val!r}, "
-        f"cli {cli_kind} {cli_val!r}"
+        f"outcome mismatch: socket {socket_kind} {socket_val!r}, cli {cli_kind} {cli_val!r}"
     )
     if socket_kind == "returned":
         assert_parity(socket_val, cli_val, drop=drop)

--- a/tests/integration/test_parity.py
+++ b/tests/integration/test_parity.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import signal
 import time
+from typing import ClassVar
 
 import ops
 import pytest
@@ -182,9 +183,7 @@ class TestFileParity:
         content = b"\x00\x01\x02\x03\xff\xfe\xfd"
         for client in twins.both:
             client.push("/tmp/parity_bin", content)
-        s, c = both_results(
-            twins, lambda cl: cl.pull("/tmp/parity_bin", encoding=None).read()
-        )
+        s, c = both_results(twins, lambda cl: cl.pull("/tmp/parity_bin", encoding=None).read())
         assert s == c == content
 
     def test_list_files(self, twins: Twins):
@@ -199,17 +198,13 @@ class TestFileParity:
         for client in twins.both:
             client.push("/tmp/parity_glob/keep.log", "x", make_dirs=True)
             client.push("/tmp/parity_glob/skip.txt", "y", make_dirs=True)
-        s, c = both_results(
-            twins, lambda cl: cl.list_files("/tmp/parity_glob", pattern="*.log")
-        )
+        s, c = both_results(twins, lambda cl: cl.list_files("/tmp/parity_glob", pattern="*.log"))
         assert_parity(s, c)
 
     def test_make_dir(self, twins: Twins):
         for client in twins.both:
             client.make_dir("/tmp/parity_mkdir/sub", make_parents=True)
-        s, c = both_results(
-            twins, lambda cl: cl.list_files("/tmp/parity_mkdir", itself=True)
-        )
+        s, c = both_results(twins, lambda cl: cl.list_files("/tmp/parity_mkdir", itself=True))
         assert_parity(s, c)
 
     def test_remove_path(self, twins: Twins):
@@ -225,9 +220,7 @@ class TestFileParity:
 
 class TestExecParity:
     def test_exec_simple(self, twins: Twins):
-        s, c = both_results(
-            twins, lambda cl: cl.exec(["echo", "hello world"]).wait_output()
-        )
+        s, c = both_results(twins, lambda cl: cl.exec(["echo", "hello world"]).wait_output())
         assert s == c
 
     def test_exec_environment(self, twins: Twins):
@@ -239,15 +232,11 @@ class TestExecParity:
         assert s == c
 
     def test_exec_working_dir(self, twins: Twins):
-        s, c = both_results(
-            twins, lambda cl: cl.exec(["pwd"], working_dir="/tmp").wait_output()
-        )
+        s, c = both_results(twins, lambda cl: cl.exec(["pwd"], working_dir="/tmp").wait_output())
         assert s == c
 
     def test_exec_stdin(self, twins: Twins):
-        s, c = both_results(
-            twins, lambda cl: cl.exec(["cat"], stdin="piped\n").wait_output()
-        )
+        s, c = both_results(twins, lambda cl: cl.exec(["cat"], stdin="piped\n").wait_output())
         assert s == c
 
     def test_exec_failure(self, twins: Twins):
@@ -337,7 +326,7 @@ class TestNoticeParity:
 class TestIdentityParity:
     # Use 'local' (user-id) identities: 'basic' auth stores a salted password
     # hash that differs between daemons, which is not a real divergence.
-    IDENTITIES: dict[str, ops.pebble.IdentityDict] = {
+    IDENTITIES: ClassVar[dict[str, ops.pebble.IdentityDict]] = {
         "alice": {"access": "admin", "local": {"user-id": 1000}}
     }
 
@@ -367,9 +356,7 @@ class TestErrorParity:
 
     def test_pull_missing_file(self, twins: Twins):
         # Both must raise ops.pebble.PathError (not APIError).
-        socket_exc, _ = assert_same_exception(
-            twins, lambda cl: cl.pull("/nonexistent/file.txt")
-        )
+        socket_exc, _ = assert_same_exception(twins, lambda cl: cl.pull("/nonexistent/file.txt"))
         assert isinstance(socket_exc, ops.pebble.PathError)
 
     def test_remove_missing_file(self, twins: Twins):

--- a/tests/integration/test_shimmer.py
+++ b/tests/integration/test_shimmer.py
@@ -16,7 +16,7 @@ import pathlib
 import subprocess
 import tempfile
 import time
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import ops
 import pytest
@@ -24,6 +24,9 @@ import pytest
 from shimmer import PebbleCliClient
 
 from .conftest import BASE_LAYER
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 pytestmark = pytest.mark.integration
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -63,9 +63,7 @@ class TestPebbleCliClient:
         mock_subprocess.run.assert_called_once()
         assert result.stdout == "success"
 
-    def test_run_command_with_input(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_run_command_with_input(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test command execution with input data."""
         mock_subprocess.run.return_value.stdout = "success"
 
@@ -81,9 +79,7 @@ class TestPebbleCliClient:
         with pytest.raises(ops.pebble.TimeoutError):
             client._run_command(["test"])
 
-    def test_run_command_api_error(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_run_command_api_error(self, mock_subprocess: Mock, client: PebbleCliClient):
         """An unclassifiable CLI error maps to a 500 with the stripped message."""
         mock_subprocess.run.side_effect = subprocess.CalledProcessError(
             1, "cmd", stderr="error: something went wrong"
@@ -144,9 +140,7 @@ class TestPebbleCliClient:
         message: str,
     ):
         """CLI stderr is classified into the HTTP status the socket client uses."""
-        mock_subprocess.run.side_effect = subprocess.CalledProcessError(
-            1, "cmd", stderr=stderr
-        )
+        mock_subprocess.run.side_effect = subprocess.CalledProcessError(1, "cmd", stderr=stderr)
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
             client._run_command(["test"])
@@ -162,9 +156,7 @@ class TestPebbleCliClient:
         self, mock_subprocess: Mock, client: PebbleCliClient
     ):
         """An error with no stderr still produces a usable message."""
-        mock_subprocess.run.side_effect = subprocess.CalledProcessError(
-            3, "cmd", stderr=""
-        )
+        mock_subprocess.run.side_effect = subprocess.CalledProcessError(3, "cmd", stderr="")
 
         with pytest.raises(ops.pebble.APIError) as exc_info:
             client._run_command(["test"])
@@ -172,9 +164,7 @@ class TestPebbleCliClient:
         assert "code 3" in exc_info.value.message
         assert exc_info.value.code == 500
 
-    def test_run_command_file_not_found(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_run_command_file_not_found(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test handling of missing pebble binary."""
         mock_subprocess.run.side_effect = FileNotFoundError()
 
@@ -223,9 +213,7 @@ class TestPebbleCliClient:
         assert call_args[:3] == ["mock-pebble", "add", "test-layer"]
         assert call_args[3].endswith(".yaml")
 
-    def test_add_layer_with_combine(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_add_layer_with_combine(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test adding a layer with combine option."""
         layer_yaml = "services:\n  test:\n    command: echo test"
 
@@ -266,9 +254,7 @@ class TestPebbleCliClient:
             "--no-wait",
         ]
 
-    def test_replan_services_no_wait(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_replan_services_no_wait(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test replanning services with no wait."""
         mock_subprocess.run.return_value.stdout = "Change 42 submitted"
 
@@ -309,9 +295,7 @@ class TestPebbleCliClient:
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "services", "--format", "json"]
 
-    def test_get_services_filtered(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_get_services_filtered(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting specific services by name."""
         # Pebble does the name filtering itself, so it only returns the match.
         mock_subprocess.run.return_value.stdout = json.dumps(
@@ -400,27 +384,21 @@ class TestPebbleCliClient:
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
 
-    def test_send_signal_bare_name(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_send_signal_bare_name(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test sending signal by bare name without the 'SIG' prefix."""
         client.send_signal("HUP", ["service1"])
 
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
 
-    def test_send_signal_lowercase_name(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_send_signal_lowercase_name(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test sending signal by lowercase name."""
         client.send_signal("sighup", ["service1"])
 
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "signal", "HUP", "service1"]
 
-    def test_send_signal_invalid_name(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_send_signal_invalid_name(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test that an invalid signal name raises ValueError."""
         with pytest.raises(ValueError, match="Invalid signal name"):
             client.send_signal("NOTASIGNAL", ["service1"])
@@ -473,9 +451,7 @@ class TestPebbleCliClient:
         assert by_name["check2"].failures == 3
         assert by_name["check2"].status == ops.pebble.CheckStatus.DOWN
 
-    def test_get_checks_with_level(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_get_checks_with_level(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test getting checks filtered by level."""
         mock_subprocess.run.return_value.stdout = json.dumps({"checks": {}})
 
@@ -588,9 +564,7 @@ class TestPebbleCliClient:
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args == ["mock-pebble", "ls", "/path", "--format", "json"]
 
-    def test_list_files_with_pattern(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_list_files_with_pattern(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test listing files with pattern."""
         mock_subprocess.run.return_value.stdout = json.dumps(
             {
@@ -911,9 +885,7 @@ class TestPebbleCliClient:
         in_progress = client.get_changes(select=ops.pebble.ChangeState.IN_PROGRESS)
         assert [c.id for c in in_progress] == ["2"]
 
-    def test_get_changes_for_service(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_get_changes_for_service(self, mock_subprocess: Mock, client: PebbleCliClient):
         """Test that a service filter is passed through as a positional arg."""
         mock_subprocess.run.return_value.stdout = json.dumps({"changes": []})
         client.get_changes(service="demo-server")
@@ -993,18 +965,14 @@ class TestPebbleCliClient:
         with pytest.raises(ops.pebble.TimeoutError, match="timed out"):
             client.wait_change(ops.pebble.ChangeID("2"), timeout=0)
 
-    def test_wait_change_polls_until_ready(
-        self, mock_subprocess: Mock, client: PebbleCliClient
-    ):
+    def test_wait_change_polls_until_ready(self, mock_subprocess: Mock, client: PebbleCliClient):
         """wait_change keeps polling until the change reports ready."""
         not_ready = Mock(returncode=0, stderr="", stdout=self._change_json(ready=False))
         is_ready = Mock(returncode=0, stderr="", stdout=self._change_json(ready=True))
         mock_subprocess.run.side_effect = [not_ready, not_ready, is_ready]
 
         with patch("shimmer._client.time.sleep") as mock_sleep:
-            change = client.wait_change(
-                ops.pebble.ChangeID("2"), timeout=10.0, delay=0.01
-            )
+            change = client.wait_change(ops.pebble.ChangeID("2"), timeout=10.0, delay=0.01)
 
         assert change.ready
         assert mock_subprocess.run.call_count == 3
@@ -1048,9 +1016,7 @@ class TestPebbleCliClient:
                         key="87",
                         occurrences=3,
                     ),
-                    self._notice_dict(
-                        "42", key="demo.example.com/test", occurrences=10
-                    ),
+                    self._notice_dict("42", key="demo.example.com/test", occurrences=10),
                 ]
             }
         )
@@ -1078,9 +1044,7 @@ class TestPebbleCliClient:
         """Type and key filters are passed as --type/--key flags, not positionally."""
         mock_subprocess.run.return_value.stdout = '{"notices":[]}'
 
-        client.get_notices(
-            types=[ops.pebble.NoticeType.CUSTOM], keys=["example.com/foo"]
-        )
+        client.get_notices(types=[ops.pebble.NoticeType.CUSTOM], keys=["example.com/foo"])
 
         call_args = mock_subprocess.run.call_args[0][0]
         assert call_args[call_args.index("--type") + 1] == "custom"
@@ -1174,12 +1138,8 @@ class TestPebbleCliClient:
         assert len(warnings) == 1
         w = warnings[0]
         assert w.message == "something is off"
-        assert w.first_added == datetime.datetime(
-            2026, 7, 14, 12, 0, 0, tzinfo=datetime.UTC
-        )
-        assert w.last_added == datetime.datetime(
-            2026, 7, 14, 12, 5, 0, tzinfo=datetime.UTC
-        )
+        assert w.first_added == datetime.datetime(2026, 7, 14, 12, 0, 0, tzinfo=datetime.UTC)
+        assert w.last_added == datetime.datetime(2026, 7, 14, 12, 5, 0, tzinfo=datetime.UTC)
         assert w.last_shown is None
         assert w.expire_after == "672h0m0s"
         assert w.repeat_after == "24h0m0s"
@@ -1265,9 +1225,7 @@ class TestPebbleCliClient:
         """replace_identities writes the identities as YAML and uses --replace."""
         captured = self._capture_from_file(mock_subprocess)
 
-        client.replace_identities(
-            {"alice": {"access": "admin", "local": {"user-id": 1000}}}
-        )
+        client.replace_identities({"alice": {"access": "admin", "local": {"user-id": 1000}}})
 
         cmd = mock_subprocess.run.call_args[0][0]
         assert cmd[:3] == ["mock-pebble", "update-identities", "--from"]
@@ -1282,9 +1240,7 @@ class TestPebbleCliClient:
         """An Identity object is serialised via to_dict()."""
         captured = self._capture_from_file(mock_subprocess)
 
-        identity = ops.pebble.Identity.from_dict(
-            {"access": "read", "local": {"user-id": 42}}
-        )
+        identity = ops.pebble.Identity.from_dict({"access": "read", "local": {"user-id": 42}})
         client.replace_identities({"bob": identity})
 
         assert captured["data"]["identities"]["bob"]["access"] == "read"
@@ -1323,9 +1279,7 @@ class TestRunnerInjection:
                 result.returncode = 0
                 return result
 
-            def popen(
-                self, argv, *, stdin, stdout, stderr, text, env=None
-            ):  # pragma: no cover
+            def popen(self, argv, *, stdin, stdout, stderr, text, env=None):  # pragma: no cover
                 raise NotImplementedError
 
         client = PebbleCliClient(pebble_binary="my-pebble", runner=FakeRunner())
@@ -1437,8 +1391,7 @@ class TestCompatibilityWithOpsPebble:
         protocol_methods = {
             name
             for name in dir(PebbleClientProtocol)
-            if not name.startswith("_")
-            and callable(getattr(PebbleClientProtocol, name, None))
+            if not name.startswith("_") and callable(getattr(PebbleClientProtocol, name, None))
         }
         assert protocol_methods, "no protocol methods discovered"
         missing = [m for m in sorted(protocol_methods) if not hasattr(client, m)]
@@ -1472,9 +1425,7 @@ class TestCompatibilityWithOpsPebble:
             assert param in exec_params, f"Missing parameter in exec(): {param}"
 
     @patch("shimmer._process.subprocess.run")
-    def test_error_handling_compatibility(
-        self, mock_run: Mock, client: PebbleCliClient
-    ):
+    def test_error_handling_compatibility(self, mock_run: Mock, client: PebbleCliClient):
         """Test that errors are raised in a compatible way."""
         mock_run.side_effect = subprocess.CalledProcessError(
             1, "cmd", stderr='error: cannot find change with id "1"'

--- a/uv.lock
+++ b/uv.lock
@@ -229,6 +229,7 @@ dev = [
     { name = "ruff" },
     { name = "tox" },
     { name = "ty" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -243,9 +244,10 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
-    { name = "ruff", specifier = "==0.15.21" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "tox", specifier = ">=4.0.0" },
     { name = "ty", specifier = "==0.0.61" },
+    { name = "zizmor", specifier = ">=1.28.0" },
 ]
 
 [[package]]
@@ -415,27 +417,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -572,4 +574,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/92/6b58872ac1184a441037bdc05c658a3900f49401b25f6e834a268ef6ff52/zizmor-1.28.0.tar.gz", hash = "sha256:6d5a300b80bf4c12e9cbe78ffd3874ec3f94b65bea78c994ec18157e2846ece0", size = 550169, upload-time = "2026-07-21T22:16:27.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/48/a725a1c34e5565eeeb4e4a93c59662f206e5156f2029627c66b2373edf55/zizmor-1.28.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:149dba59a8bd2897960ee54c40ae8b5801a71293bad71c8d2913c74ab66a294c", size = 8909502, upload-time = "2026-07-21T22:16:07.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/ba6d0eb2b336b4c4826bb0c9ed23c3239d46d71d8c1ddd2d395efeff7f52/zizmor-1.28.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0949f57a6d20deeb9c509705afce8de233c166475e25be305985a1fe553c6e0d", size = 8520554, upload-time = "2026-07-21T22:16:09.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/07/69aba8157056fc0949cbdc787d8437813961e204a117c629d34afc827d6d/zizmor-1.28.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:9819f91f0ef486e4af98a6aacfed23c6b4067fabcecb88d49231228a3d43f821", size = 8759226, upload-time = "2026-07-21T22:16:11.627Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/b65717a3ca4573611f47612e67be5458ff700e857f49f759741fa67b0519/zizmor-1.28.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:354e6cb98a15a88593a6f7ac6236b092b83a2aad5c4768ee750f9b3262f668d9", size = 8382005, upload-time = "2026-07-21T22:16:13.896Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b4/f823bd2a1ba6dc432fdcbd249d4c442ce79bd137d34d986fce5c181f2800/zizmor-1.28.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ae2cab67ce713e760e0d1b61ad749d374693ea2b310337aab11cd446748267f3", size = 9175601, upload-time = "2026-07-21T22:16:16.177Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/adad17b0320eb3bc9ed797019fccf69a809affdf5ba9402bdc8b910957e1/zizmor-1.28.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7b00018cf2cc948c3b3e010c1a1f30fdc001f0d062640469f17e0ef006e74eb7", size = 8792861, upload-time = "2026-07-21T22:16:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/3d/4d5583f24730f404c104eacf8aca4ca5a3d4c480e9d3cfe3eadd93351fd6/zizmor-1.28.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6897f02b0d02fd709f5ebc13cd37d97ad464219e0ba86a03f6d86f7777b7b102", size = 8343070, upload-time = "2026-07-21T22:16:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e2/4521e6dd56bc0d44eefb177794e261925c5cd00ab647b17e5513bddcb985/zizmor-1.28.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ef69d198dcf6835c9b6eea8673cbc5c36f10b3f1b98b51d28266b7e01c3704d4", size = 9262222, upload-time = "2026-07-21T22:16:21.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/5d841d197c821921cb8243352c610ca2505a86871c10f81efe4da190d24c/zizmor-1.28.0-py3-none-win32.whl", hash = "sha256:833c360ba5a9c74ca45007b8c79939826fca0c5ed65144fa08f63a7009cef096", size = 7541161, upload-time = "2026-07-21T22:16:23.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f5/3f4591746e5a9c7e8efc2e9e02aa43e1aa0957fe33cae64ce386c74b882e/zizmor-1.28.0-py3-none-win_amd64.whl", hash = "sha256:c93b30d211b0b0c38905a8803cc2653fff37de03eb77105302a02f709773bd4a", size = 8619340, upload-time = "2026-07-21T22:16:25.6Z" },
 ]


### PR DESCRIPTION
Adopt a shared ruff ruleset, update ruff to 0.16.0, and resolve everything it reports so both `ruff check` and `ruff format --check` pass cleanly.

- Pin ruff to 0.16.0.
- Adopt the shared ruleset for this project type (no mccabe complexity rules).
- Exempt test directories from docstring and assert rules.
- Apply ruff's fixes and formatting across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)