### PR TITLE
fix: Restore ruff settings dropped by the standardisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ precision = 2
 directory = "htmlcov"
 
 [tool.ruff]
+src = ["src", "tests"]
 line-length = 99
 target-version = "py311"
 
@@ -118,6 +119,7 @@ select = [
     "YTT",
     "S",
     "B",
+    "C4",
     "SIM",
     "RUF",
     "PERF",
@@ -154,3 +156,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "demo.py" = ["S108", "S103", "D103"]  # A throwaway demo script, not shipped code.
 "**/tests/**" = ["S101", "S105", "S106", "S108", "PLR2004", "ARG", "SLF001", "N802", "N803", "N806", "D"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["shimmer"]
+
+# Pytest configuration


### PR DESCRIPTION
The ruff standardisation rewrote the [tool.ruff] section wholesale and lost settings that were orthogonal to the select/ignore lists it was changing. This restores them; the select and ignore lists are left as standardised.

- Restore src = ["src", "tests"] and isort known-first-party.
- Restore flake8-comprehensions (C4) to select; only mccabe (C90) was meant to go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)